### PR TITLE
Correcting description of simulator m option

### DIFF
--- a/src/constants.cc
+++ b/src/constants.cc
@@ -644,7 +644,7 @@ static const cstring basic_constants[] =
     // *Tau mass - Measurement
     "mτ",       "[ 1.90754_u "
                 "  0.00013_u "
-                "  'ROUND(UBASE(Ⓢmμ/Ⓒmμ);-2)' ]",
+                "  'ROUND(UBASE(Ⓢmτ/Ⓒmτ);-2)' ]",
 
     // ------------------------------------------------------------------------
     // *mpme ratio - Measurement


### PR DESCRIPTION
The description for the m option of the simulator mentions megabyte. It should be kilobytes.