### PR TITLE
Fix CI after release 0.9.18

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,8 @@ This directory contains GitHub Actions workflows for automated building and test
 
 ### build.yml
 
-Main build workflow that runs on every push and pull request to main/master/develop branches.
+Main build workflow that runs on pushes and pull requests for the `stable` and
+`dev` branches, plus manual dispatches, published releases, and version tags.
 
 #### Jobs
 
@@ -28,8 +29,8 @@ Main build workflow that runs on every push and pull request to main/master/deve
 
 3. **build-simulator-windows** - Builds the Windows simulator
    - Platform: Windows (latest)
-   - Requirements: Qt 6.7.3 (includes MinGW 9.0), MSYS2 (FreeType, pkg-config)
-   - Target: `mingw32-make sim`
+   - Requirements: MSYS2 MinGW64 with Qt 6 packages, `libsystre`, FreeType, and `pkg-config`
+   - Target: `mingw32-make debug-sim`
    - Build ID: Uses GitHub Actions run number
    - Artifacts: `db48x.exe`, DLLs, help files
 
@@ -51,8 +52,8 @@ Main build workflow that runs on every push and pull request to main/master/deve
 
 6. **build-color-simulator-windows** - Builds the color DM32 simulator for Windows
    - Platform: Windows (latest)
-   - Requirements: Qt 6.7.3 (includes MinGW 9.0), MSYS2 (FreeType, pkg-config)
-   - Target: `mingw32-make color-dm32-sim`
+   - Requirements: MSYS2 MinGW64 with Qt 6 packages, `libsystre`, FreeType, and `pkg-config`
+   - Target: `mingw32-make debug-color-dm32-sim`
    - Build ID: Uses GitHub Actions run number
    - Artifacts: `db50x.exe`, DLLs, help files
 
@@ -96,9 +97,9 @@ Main build workflow that runs on every push and pull request to main/master/deve
    - Artifacts: Distribution tarball (`db50x-v*.tgz`) with `.pg5`, `_qspi.bin`, help files
 
 12. **build-release-package** - Creates release packages
-    - Runs only on pushes to main/master
-    - Depends on all other build jobs
-    - Creates `.tar.gz` archives of firmware builds
+   - Runs only for version-tag pushes
+   - Depends on all other build jobs
+   - Creates `.tar.gz` archives of firmware builds
 
 ## Code Signing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,14 +486,19 @@ jobs:
 
     - name: List generated AAB files
       run: |
-        echo "Looking for AAB files in android directory:"
-        find android -name "*.aab" -type f 2>/dev/null || echo "No AAB files found"
+        echo "Looking for AAB files in workspace:"
+        find . -name "*.aab" -type f 2>/dev/null || echo "No AAB files found"
+
+    - name: Verify generated AAB
+      run: test -f android/db48x.aab
 
     - name: Upload Android artifacts
       uses: actions/upload-artifact@v7
       with:
         name: db48x-android
+        if-no-files-found: error
         path: |
+          android/*.aab
           android/**/*.aab
           help/
 
@@ -552,14 +557,19 @@ jobs:
 
     - name: List generated AAB files
       run: |
-        echo "Looking for AAB files in android directory:"
-        find android -name "*.aab" -type f 2>/dev/null || echo "No AAB files found"
+        echo "Looking for AAB files in workspace:"
+        find . -name "*.aab" -type f 2>/dev/null || echo "No AAB files found"
+
+    - name: Verify generated AAB
+      run: test -f android/db50x.aab
 
     - name: Upload Android artifacts
       uses: actions/upload-artifact@v7
       with:
         name: db50x-android
+        if-no-files-found: error
         path: |
+          android/*.aab
           android/**/*.aab
           help/
 
@@ -759,10 +769,12 @@ jobs:
         mv artifacts/db50x-dm32-*.tar.gz releases/db50x-dm32.tar.gz
         mv artifacts/db50x-dm42n-*.tar.gz releases/db50x-dm42n.tar.gz
 
-    - name: Move Android artifacts
+    - name: Package Android artifacts
       run: |
-        mv artifacts/db48x-android-*.tar.gz releases/db48x-android.tar.gz
-        mv artifacts/db50x-android-*.tar.gz releases/db50x-android.tar.gz
+        cd artifacts/db48x-android
+        tar czf ../../releases/db48x-android.tar.gz *
+        cd ../db50x-android
+        tar czf ../../releases/db50x-android.tar.gz *
 
     - name: Extract tag message for release body
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           mingw-w64-x86_64-make
           mingw-w64-x86_64-freetype
           mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-libgnurx
+          mingw-w64-x86_64-libsystre
           mingw-w64-x86_64-qt6-base
           mingw-w64-x86_64-qt6-declarative
           mingw-w64-x86_64-qt6-multimedia
@@ -154,7 +154,8 @@ jobs:
         cp /mingw64/bin/libgcc_s_seh-1.dll .
         cp /mingw64/bin/libstdc++-6.dll .
         cp /mingw64/bin/libwinpthread-1.dll .
-        cp /mingw64/bin/libgnurx-0.dll .
+        cp /mingw64/bin/libsystre-0.dll .
+        cp /mingw64/bin/libtre-5.dll .
         cp /mingw64/bin/libintl-8.dll .
         cp /mingw64/bin/libiconv-2.dll .
         # Copy all Qt dependency DLLs
@@ -316,7 +317,7 @@ jobs:
           mingw-w64-x86_64-make
           mingw-w64-x86_64-freetype
           mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-libgnurx
+          mingw-w64-x86_64-libsystre
           mingw-w64-x86_64-qt6-base
           mingw-w64-x86_64-qt6-declarative
           mingw-w64-x86_64-qt6-multimedia
@@ -337,7 +338,8 @@ jobs:
         cp /mingw64/bin/libgcc_s_seh-1.dll .
         cp /mingw64/bin/libstdc++-6.dll .
         cp /mingw64/bin/libwinpthread-1.dll .
-        cp /mingw64/bin/libgnurx-0.dll .
+        cp /mingw64/bin/libsystre-0.dll .
+        cp /mingw64/bin/libtre-5.dll .
         cp /mingw64/bin/libintl-8.dll .
         cp /mingw64/bin/libiconv-2.dll .
         # Copy all Qt dependency DLLs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,6 +401,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfreetype6-dev pkg-config
 
+    - name: Generate recorder config header
+      run: |
+        make -C recorder TARGET=opt BUILDENV=auto RECURSE=.config .config
+        cp recorder/.build/linux/opt/config.h recorder/config.h
+
     - name: Setup Emscripten
       uses: mymindstorm/setup-emsdk@v14
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,11 +140,11 @@ jobs:
           mingw-w64-x86_64-qt6-translations
           mingw-w64-x86_64-qt6-tools
 
-    - name: Build simulator
+    - name: Build debug simulator
       shell: msys2 {0}
       run: |
         echo "${{ github.run_number }}" > .build_id
-        mingw32-make sim
+        mingw32-make debug-sim
 
     - name: Deploy Qt dependencies
       shell: msys2 {0}
@@ -182,7 +182,7 @@ jobs:
       if: ${{ env.WINDOWS_CERT_DATA != '' }}
       uses: lando/code-sign-action@v3
       with:
-        file: debug/db48x.exe
+        file: db48x.exe
         certificate-data: ${{ secrets.WINDOWS_CERT_DATA }}
         certificate-password: ${{ secrets.WINDOWS_CERT_PASSWORD }}
 
@@ -324,11 +324,11 @@ jobs:
           mingw-w64-x86_64-qt6-translations
           mingw-w64-x86_64-qt6-tools
 
-    - name: Build color DM32 simulator
+    - name: Build debug color DM32 simulator
       shell: msys2 {0}
       run: |
         echo "${{ github.run_number }}" > .build_id
-        mingw32-make color-dm32-sim
+        mingw32-make debug-color-dm32-sim
 
     - name: Deploy Qt dependencies
       shell: msys2 {0}
@@ -366,7 +366,7 @@ jobs:
       if: ${{ env.WINDOWS_CERT_DATA != '' }}
       uses: lando/code-sign-action@v3
       with:
-        file: debug/db50x.exe
+        file: db50x.exe
         certificate-data: ${{ secrets.WINDOWS_CERT_DATA }}
         certificate-password: ${{ secrets.WINDOWS_CERT_PASSWORD }}
 
@@ -375,12 +375,12 @@ jobs:
       with:
         name: db50x-color-simulator-windows
         path: |
-          debug/db50x.exe
-          debug/*.dll
-          debug/platforms/
-          debug/imageformats/
-          debug/tls/
-          debug/translations/
+          db50x.exe
+          *.dll
+          platforms/
+          imageformats/
+          tls/
+          translations/
           help/
 
   build-wasm:

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ TOOLS_BUILDS=$(dir $(wildcard tools/*/Makefile))
 TOOLS=$(foreach t,$(TOOLS_BUILDS),$t$(notdir $(t:%/=%)))
 tools: $(TOOLS)
 tools/%:
-	$(PRINT_COMMAND) cd tools/$(*D) && $(MAKE) BUILDENV=auto TIME= DO_INSTALL= VARIANT=$(*D)
+	$(PRINT_COMMAND) cd tools/$(*D) && $(MAKE) BUILDENV=auto TIME= DO_INSTALL= VARIANT=$(*D) OUTPUT=./
 
 clangdb: clangdb-color-dm32-sim
 clangdb-%: .ALWAYS

--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,10 @@ QMAKE_ENV = 	export ANDROID_SDK_ROOT=$(ANDROID_SDK_ROOT) ;	\
 		export ANDROID_NDK_ROOT=$(ANDROID_NDK_ROOT) ;	\
 		export KEYSTORE_PATH=$(ANDROID_KEYSTORE) ;	\
 		export JAVA_HOME=$(ANDROID_JAVA_HOME);
-AAB_FILE=$(OUTPUT:%=%/)$(NAME).aab
+# make-it-quick defaults OUTPUT to the workspace root; keep Android bundles
+# under android/ unless the caller overrides ANDROID_OUTPUT_DIR explicitly.
+ANDROID_OUTPUT_DIR ?= android
+AAB_FILE=$(ANDROID_OUTPUT_DIR:%=%/)$(NAME).aab
 
 android-$(TARGET): $(AAB_FILE)
 android-%: qt-%
@@ -585,18 +588,27 @@ android-%: qt-%
 $(QMAKEFILE): sim/android/AndroidManifest.xml sim/android/build.gradle
 
 # Deploy (and optionally sign) the AAB via androiddeployqt. androiddeployqt
-# expects the .so at <output>/libs/arm64-v8a/; the qmake build puts it in
-# DESTDIR, so we must run make install INSTALL_ROOT=<output> first.
+# expects a build directory as --output and the .so staged under
+# <output>/libs/arm64-v8a/, so we must run make install INSTALL_ROOT=<output>
+# first. Normalize the final bundle to $(AAB_FILE) so workflows and helper
+# scripts can upload a stable path.
 $(AAB_FILE): $(QMAKEFILE) qt-$(TARGET)
 	$(PRINT_COMMAND) 						\
 		AAB="$(abspath $@)";					\
+		OUTDIR="$(abspath $(dir $@))";				\
+		mkdir -p "$$OUTDIR" &&					\
 		cd sim && 						\
-		$(MAKE) -f $(<F)  install INSTALL_ROOT="$$AAB" &&	\
+		$(MAKE) -f $(<F)  install INSTALL_ROOT="$$OUTDIR" &&	\
 		$(QMAKE_ENV)						\
 		$(ANDROID_DEPLOY_QT)					\
 		  --input android-$(NAME)-deployment-settings.json	\
-		  --output "$$AAB" --gradle --aab			\
-		  $(ANDROID_DEPLOY_SIGN_FLAGS)
+		  --output "$$OUTDIR" --gradle --aab			\
+		  $(ANDROID_DEPLOY_SIGN_FLAGS) &&			\
+		if [ ! -f "$$AAB" ]; then				\
+			BUILT_AAB="$$(find "$$OUTDIR" -type f -name '*.aab' | sort | tail -1)"; \
+			[ -n "$$BUILT_AAB" ] && cp "$$BUILT_AAB" "$$AAB"; \
+		fi &&						\
+		test -f "$$AAB"
 	$(if $(ANDROID_CAN_SIGN),,$(PRINT_COMMAND) $(INFO) "[WARNING]" "Android AAB is UNSIGNED (need $(ANDROID_KEYSTORE) and ANDROID_KEYSTORE_PASS). Not for Play Store.")
 
 endif


### PR DESCRIPTION
**fix(ci): use libsystre in Windows packaging**
MSYS2 now removes libgnurx from the install set because it conflicts with
libsystre, which is pulled in by the current Qt dependency graph.

Update the Windows workflow to install libsystre and copy libsystre-0.dll
and libtre-5.dll instead of the missing libgnurx-0.dll.


**fix(wasm): bootstrap recorder and host tools correctly**
Generate recorder/config.h in the GitHub wasm job before the emsdk build
so clean checkouts do not fail when recorder.c includes the header.

Force host tools to build with OUTPUT=./ so wasm does not place
ttf2font and decimize under nested wasm/ directories that the top-level
rules do not invoke.


**fix(ci): package db50x Windows simulator from the correct path**
The color Windows job signs and uploads debug/db50x.exe and debug/*
even though the build and windeployqt6 place the simulator files at the
workspace root.

Update the artifact and signing paths so the db50x archive includes the
executable, deployed DLLs, Qt plugin directories, and help files.

Use the same process for db48x.exe for consistency.


**fix(ci): keep Android AABs under android/**
Make the Android bundle path independent from the generic OUTPUT
variable, which defaults to the workspace root in CI.

Verify android/db48x.aab and android/db50x.aab before upload and
fail the artifact step when no AAB is present.