### PR TITLE
Fix: Root solver converges prematurely in Std display mode

### DIFF
--- a/src/algebraic.cc
+++ b/src/algebraic.cc
@@ -1396,7 +1396,9 @@ algebraic_p algebraic::epsilon(int impr)
 {
     int         disp = Settings.DisplayDigits();
     int         prec = Settings.Precision();
-    int         dig  = std::min(disp + 1, std::max(prec - impr, 3));
+    int         dig  = Settings.DisplayMode() == object::ID_Std
+                           ? std::max(prec - impr, 3)
+                           : std::min(disp + 1, std::max(prec - impr, 3));
     algebraic_p eps  = decimal::make(1, -dig);
     return eps;
 }


### PR DESCRIPTION
Fixes #1679

In `Std` mode, `algebraic::epsilon()` used `DisplayDigits() + 1 = 21`
as the convergence target regardless of `Precision`, causing the solver
to stop after ~20 digits instead of `Precision - SolverImprecision`.

The fix skips the `std::min(disp+1, ...)` clamp in `Std` mode and uses
`max(prec - impr, 3)` directly, consistent with documented behaviour.

Tested: `Prec 1010`, `Std`, `'cos X-X' 'X' 0.7 Root` → ≥1004 accurate digits.