### PR TITLE
sim: Persist window geometry across runs

### DIFF
--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -177,6 +177,15 @@ MainWindow::MainWindow(QWidget *parent)
 
     setlocale(LC_ALL, "C");
 
+#ifndef ANDROID
+    // Restore last window geometry if we have one (must come before the
+    // manual layout pass below, since we disabled automatic layout)
+    QSettings settings;
+    QByteArray savedGeometry = settings.value("MainWindow/geometry").toByteArray();
+    if (!savedGeometry.isEmpty())
+        restoreGeometry(savedGeometry);
+#endif
+
     // Set initial geometry manually since we disabled layout management
     QResizeEvent initialResize(size(), size());
     resizeEvent(&initialResize);
@@ -204,6 +213,19 @@ MainWindow::~MainWindow()
 {
     key_push(tests::EXIT_PGM);
     record(sim_audio, "Deleting audio");
+}
+
+
+void MainWindow::closeEvent(QCloseEvent *event)
+// ----------------------------------------------------------------------------
+//  Persist window geometry across runs
+// ----------------------------------------------------------------------------
+{
+#ifndef ANDROID
+    QSettings settings;
+    settings.setValue("MainWindow/geometry", saveGeometry());
+#endif
+    QMainWindow::closeEvent(event);
 }
 
 

--- a/sim/sim-window.h
+++ b/sim/sim-window.h
@@ -185,6 +185,7 @@ protected:
     virtual void keyReleaseEvent(QKeyEvent *ev);
     bool         eventFilter(QObject *obj, QEvent *ev);
     void         resizeEvent(QResizeEvent *event);
+    void         closeEvent(QCloseEvent *event);
     void         handleAppStateChange(Qt::ApplicationState state);
 
 signals:


### PR DESCRIPTION
Thanks for this project!  I wanted to try using sim mode on Mac as my desktop calculator, so making a couple of PRs with what I think are some quality of life improvements.

Save the simulator's window size and position to QSettings on close, and restore them on startup. The restore happens before the manual layout pass so the screen and keyboard widgets are sized against the restored geometry rather than the .ui-file default.