### PR TITLE
sim: Persist calculator state on exit

### DIFF
--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -106,6 +106,16 @@ MainWindow::MainWindow(QWidget *parent)
     QCoreApplication::setOrganizationName("DB48X");
     QCoreApplication::setApplicationName(PROGRAM_NAME);
 
+    // Default the persisted state file path on first run, so that the RPL
+    // engine's EXIT_PGM handler in main.cc actually writes a state file
+    // (it's a no-op when no path has been configured). The file lives
+    // under the app data dir; QDir::setCurrent() is already pointed there.
+    if (ui_read_setting("state", nullptr, 0) == 0)
+    {
+        QString defaultPath = QString("state/") + PROGRAM_NAME + ".48S";
+        ui_save_setting("state", defaultPath.toUtf8().constData());
+    }
+
     ui.setupUi(this);
 
     // Disable automatic layout management for manual control

--- a/src/dmcp/sysmenu.cc
+++ b/src/dmcp/sysmenu.cc
@@ -395,8 +395,11 @@ static int state_load_callback(cstring path, cstring name, void *data)
         file prog(path, file::READING);
         if (!prog.valid())
         {
-            ui.draw_message("State load failed", prog.error(), name);
-            wait_for_key_press();
+            if (!is_silent)
+            {
+                ui.draw_message("State load failed", prog.error(), name);
+                wait_for_key_press();
+            }
             return 1;
         }
 


### PR DESCRIPTION
The simulator already saves its state on EXIT_PGM (see src/dmcp/main.cc), but only when a state-file path has previously been configured by the user via the SETUP > State > Save menu. On a fresh install the path is empty, so closing the window silently discards all settings (Beep mode, display options, etc.) and stack contents.

Default the persisted state-file path to "state/<PROGRAM_NAME>.48S" on first launch, so that exit reliably writes a state file and the next launch reliably restores it.

Also honor STATE_IO_SILENT in state_load_callback. With the default path set, the first launch (when no state file exists yet) was popping up a "State load failed: No such file or directory" dialog; silent loads should be silent on missing files too.