### PR TITLE
Pr a orbital

### DIFF
--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1091,6 +1091,17 @@ It is the measured angle between the ascending node (where the orbit crosses
 the reference plane northward) and the perihelion (the closest point to the
 Sun), measured in the direction of motion. [Reference 23](#reference-23)
 
+### Porb☿ constant
+
+Mercury orbital period
+
+Mercury's sidereal orbital period — the time to complete one revolution around
+the Sun. It is distinct from the rotation period `Prot☿` (the spin period).
+Computed from Meeus' Chapter 38 orbital elements and cross-checked against JPL
+Horizons. The stored value is a mean orbital period, used as an approximation of
+the anomalistic period that governs the recurrence of the perihelion passages
+exposed by `T₀☿`. [Materials 22](#materials-22) [Reference 23](#reference-23)
+
 ### T₀☿ constant
 
 Mercury last perihelion passage
@@ -1204,6 +1215,17 @@ Venus argument of perihelion
 It is the measured angle between the ascending node (where the orbit crosses
 the reference plane northward) and the perihelion (the closest point to the Sun),
 measured in the direction of motion. [Reference 23](#reference-23)
+
+### Porb♀ constant
+
+Venus orbital period
+
+Venus's sidereal orbital period — the time to complete one revolution around the
+Sun. It is distinct from the rotation period `Prot♀` (the spin period). Computed
+from Meeus' Chapter 38 orbital elements and cross-checked against JPL Horizons.
+The stored value is a mean orbital period, used as an approximation of the
+anomalistic period that governs the recurrence of the perihelion passages
+exposed by `T₀♀`. [Materials 22](#materials-22) [Reference 23](#reference-23)
 
 ### T₀♀ constant
 
@@ -1323,6 +1345,16 @@ Earth argument of perihelion
 It is the measured angle between the ascending node (where the orbit crosses
 the reference plane northward) and the perihelion (the closest point to the
 Sun), measured in the direction of motion. [Reference 23](#reference-23)
+
+### Porb♁ constant
+
+Earth orbital period
+
+Earth's sidereal orbital period — the time to complete one revolution around the
+Sun. It is distinct from the rotation period `Prot♁` (the sidereal day). Computed
+from Meeus' Chapter 38 orbital elements and cross-checked against JPL Horizons.
+The stored value is the mean (anomalistic) year used to advance `T₀♁` between
+successive perihelion passages. [Materials 22](#materials-22) [Reference 23](#reference-23)
 
 ### T₀♁ constant
 
@@ -1552,6 +1584,17 @@ It is the measured angle between the ascending node (where the orbit crosses
 the reference plane northward) and the perihelion (the closest point to the
 Sun), measured in the direction of motion. [Reference 23](#reference-23)
 
+### Porb♂ constant
+
+Mars orbital period
+
+Mars's sidereal orbital period — the time to complete one revolution around the
+Sun. It is distinct from the rotation period `Prot♂` (the spin period, close to
+an Earth day). Computed from Meeus' Chapter 38 orbital elements and cross-checked
+against JPL Horizons. The stored value is a mean orbital period, used as an
+approximation of the anomalistic period that governs the recurrence of the
+perihelion passages exposed by `T₀♂`. [Materials 22](#materials-22) [Reference 23](#reference-23)
+
 ### T₀♂ constant
 
 Mars perihelion passage
@@ -1670,6 +1713,16 @@ It is the measured angle between the ascending node (where the orbit
 crosses the reference plane northward) and the perihelion (the closest
 point to the Sun), measured in the direction of motion. [Reference 23](#reference-23)
 
+### Porb♃ constant
+
+Jupiter orbital period
+
+Jupiter's sidereal orbital period — the time to complete one revolution around
+the Sun (about 11.86 years). It is distinct from the rotation period `Prot♃`
+(the ~10 h spin period). Tabulated sidereal value from the NASA Planetary Fact
+Sheet, used as an approximation of the anomalistic period that governs the
+recurrence of the perihelion passages exposed by `T₀♃`. [Materials 23](#materials-23)
+
 ### T₀♃ constant
 
 Jupiter perihelion passage
@@ -1787,6 +1840,16 @@ It is the measured angle between the ascending node (where the orbit
 crosses the reference plane northward) and the perihelion (the closest
 point to the Sun), measured in the direction of motion. [Reference 23](#reference-23)
 
+### Porb♄ constant
+
+Saturn orbital period
+
+Saturn's sidereal orbital period — the time to complete one revolution around
+the Sun (about 29.46 years). It is distinct from the rotation period `Prot♄`
+(the ~10.7 h spin period). Tabulated sidereal value from the NASA Planetary Fact
+Sheet, used as an approximation of the anomalistic period that governs the
+recurrence of the perihelion passages exposed by `T₀♄`. [Materials 23](#materials-23)
+
 ### T₀♄ constant
 
 Saturn perihelion passage
@@ -1902,6 +1965,16 @@ Uranus argument of perihelion
 It is the measured angle between the ascending node (where the orbit
 crosses the reference plane northward) and the perihelion (the closest
 point to the Sun), measured in the direction of motion. [Reference 23](#reference-23)
+
+### Porb⛢ constant
+
+Uranus orbital period
+
+Uranus's sidereal orbital period — the time to complete one revolution around
+the Sun (about 84 years). It is distinct from the rotation period `Prot⛢` (the
+~17 h spin period). Tabulated sidereal value from the NASA Planetary Fact Sheet,
+used as an approximation of the anomalistic period that governs the recurrence
+of the perihelion passages exposed by `T₀⛢`. [Materials 23](#materials-23)
 
 ### T₀⛢ constant
 
@@ -2020,6 +2093,16 @@ It is the measured angle between the ascending node (where the orbit
 crosses the reference plane northward) and the perihelion (the closest
 point to the Sun), measured in the direction of motion. [Reference 23](#reference-23)
 
+### Porb♆ constant
+
+Neptune orbital period
+
+Neptune's sidereal orbital period — the time to complete one revolution around
+the Sun (about 165 years). It is distinct from the rotation period `Prot♆` (the
+~16 h spin period). Tabulated sidereal value from the NASA Planetary Fact Sheet,
+used as an approximation of the anomalistic period that governs the recurrence
+of the perihelion passages exposed by `T₀♆`. [Materials 23](#materials-23)
+
 ### T₀♆ constant
 
 Neptune perihelion passage
@@ -2134,6 +2217,16 @@ Pluto argument of perihelion
 It is the measured angle between the ascending node (where the orbit crosses
 the reference plane northward) and the perihelion (the closest point to the
 Sun), measured in the direction of motion. [Reference 23](#reference-23)
+
+### Porb♇ constant
+
+Pluto orbital period
+
+Pluto's sidereal orbital period — the time to complete one revolution around the
+Sun (about 248 years). It is distinct from the rotation period `Prot♇` (the
+~6.4 day spin period). Tabulated sidereal value from the NASA Planetary Fact
+Sheet, used as an approximation of the anomalistic period that governs the
+recurrence of the perihelion passages exposed by `T₀♇`. [Materials 23](#materials-23)
 
 ### T₀♇ constant
 
@@ -3506,4 +3599,8 @@ Park, R.S., et al. (2021). "The JPL Planetary and Lunar Ephemerides DE440 and DE
 
 ### Materials 22
 
-Meeus, J. (1998). Astronomical Algorithms, 2nd ed. Willmann-Bell Inc., Richmond, Virginia. ISBN: 978-0-943396-61-3. Chapter 50: Perigee and Apogee of the Moon, pp. 355–358. (Formula for lunar perigee — implemented in MPERC.txt.)
+Meeus, J. (1998). Astronomical Algorithms, 2nd ed. Willmann-Bell Inc., Richmond, Virginia. ISBN: 978-0-943396-61-3. Chapter 38: Perihelion and Aphelion of the Planets; Chapter 50: Perigee and Apogee of the Moon, pp. 355–358. (Planetary orbital periods derived from the Chapter 38 elements; lunar perigee formula from Chapter 50.)
+
+### Materials 23
+
+Williams, D.R. NASA Planetary Fact Sheet. NASA Space Science Data Coordinated Archive (NSSDCA), Goddard Space Flight Center. [Source](https://nssdc.gsfc.nasa.gov/planetary/factsheet/) Accessed: June 2026. (Sidereal orbital periods of the giant planets, used as an approximation of the anomalistic period.)

--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1104,12 +1104,14 @@ exposed by `T₀☿`. [Materials 22](#materials-22) [Reference 23](#reference-23
 
 ### T₀☿ constant
 
-Mercury last perihelion passage
+Mercury time of perihelion passage
 
-Mercury's most recent time of perihelion passage is a measured quantity.
-Mercury passes perihelion approximately four times per year. Value in JDN
-(Julian Day Number, Gregorian calendar). It is the most recent point in its
-orbit when it was closest to the Sun. [Materials 20](#materials-20)
+Computed, not stored: `T₀☿` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb☿`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`, so the constant displays as a date but tracks "now". Mercury passes
+perihelion roughly four times per year. [Materials 22](#materials-22)
 
 
 ## Venus constants
@@ -1229,11 +1231,13 @@ exposed by `T₀♀`. [Materials 22](#materials-22) [Reference 23](#reference-23
 
 ### T₀♀ constant
 
-Venus last perihelion passage
+Venus time of perihelion passage
 
-Measured. Venus's most recent time of perihelion passage. Venus passes perihelion
-approximately twice per year. Value in JDN. It is the most recent point in its
-orbit when it was closest to the Sun. [Materials 20](#materials-20)
+Computed, not stored: `T₀♀` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♀`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Venus passes perihelion about twice per year. [Materials 22](#materials-22)
 
 
 ## Earth constants
@@ -1358,11 +1362,13 @@ successive perihelion passages. [Materials 22](#materials-22) [Reference 23](#re
 
 ### T₀♁ constant
 
-Earth perihelion passage
+Earth time of perihelion passage
 
-Measured. Earth's most recent time of perihelion passage (early January each
-year). Value in JDN. It is the most recent point in its orbit when it was
-closest to the Sun. [Materials 20](#materials-20)
+Computed, not stored: `T₀♁` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♁`, the
+anomalistic year) and returns the most recent perihelion passage at or before
+the current date (early January each year). The computation is carried out in
+Julian Day Number and converted to a date with `JDN→`. [Materials 22](#materials-22)
 
 
 ## Moon constants
@@ -1597,11 +1603,13 @@ perihelion passages exposed by `T₀♂`. [Materials 22](#materials-22) [Referen
 
 ### T₀♂ constant
 
-Mars perihelion passage
+Mars time of perihelion passage
 
-Measured. Mars's most recent time of perihelion passage. Mars's orbital
-period is approximately 1.88 years. Value in JDN. It is the most recent point
-in its orbit when it was closest to the Sun. [Materials 20](#materials-20)
+Computed, not stored: `T₀♂` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♂`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Mars's orbital period is approximately 1.88 years. [Materials 22](#materials-22)
 
 
 ## Jupiter constants
@@ -1725,11 +1733,13 @@ recurrence of the perihelion passages exposed by `T₀♃`. [Materials 23](#mate
 
 ### T₀♃ constant
 
-Jupiter perihelion passage
+Jupiter time of perihelion passage
 
-Measured. Jupiter's most recent time of perihelion passage. Jupiter's
-orbital period is approximately 11.86 years. It is the most recent point
-in its orbit when it was closest to the Sun. Value in JDN. [Reference 4](#reference-4) [Materials 21](#materials-21)
+Computed, not stored: `T₀♃` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♃`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Jupiter's orbital period is approximately 11.86 years. [Materials 22](#materials-22)
 
 
 ## Saturn constants
@@ -1852,11 +1862,13 @@ recurrence of the perihelion passages exposed by `T₀♄`. [Materials 23](#mate
 
 ### T₀♄ constant
 
-Saturn perihelion passage
+Saturn time of perihelion passage
 
-Measured. Saturn's most recent time of perihelion passage. Saturn's
-orbital period is approximately 29.46 years. It is the most recent point
-in its orbit when it was closest to the Sun. Value in JDN. [Reference 4](#reference-4) [Materials 21](#materials-21)
+Computed, not stored: `T₀♄` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♄`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Saturn's orbital period is approximately 29.46 years. [Materials 22](#materials-22)
 
 
 ## Uranus constants
@@ -1978,13 +1990,15 @@ of the perihelion passages exposed by `T₀⛢`. [Materials 23](#materials-23)
 
 ### T₀⛢ constant
 
-Uranus perihelion passage
+Uranus time of perihelion passage
 
-Calculated from measurement (JPL DE440 orbital propagation). Uranus's
-predicted next time of perihelion passage (~2050). Uranus's orbital
-period is approximately 84 years. Last perihelion: 1966. It is the most
-recent point in its orbit when it was closest to the Sun. Value in JDN.
-[Reference 4](#reference-4) [Materials 21](#materials-21)
+Computed, not stored: `T₀⛢` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb⛢`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Uranus's orbital period is approximately 84 years; the last perihelion
+was in 1966 and the next is around 2050, so the returned value can be decades in
+the past. [Materials 22](#materials-22)
 
 
 ## Neptune constants
@@ -2105,13 +2119,16 @@ of the perihelion passages exposed by `T₀♆`. [Materials 23](#materials-23)
 
 ### T₀♆ constant
 
-Neptune perihelion passage
+Neptune time of perihelion passage
 
-Calculated from measurement (JPL DE440 orbital propagation). Neptune's
-predicted next time of perihelion passage (~2042). Neptune's orbital
-period is approximately 164.8 years. Last perihelion: 1876. It is the
-most recent point in its orbit when it was closest to the Sun. Value
-in JDN. [Reference 4](#reference-4) [Materials 21](#materials-21)
+Computed, not stored: `T₀♆` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♆`) and returns
+the most recent perihelion passage at or before the current date, carried out in
+Julian Day Number and converted to a date with `JDN→`. Neptune is a deliberate
+exception to the "most recent past perihelion" convention: its true last
+perihelion (~1876) is uninformative and hard to source, so Tp is set to the next
+perihelion (2042-09-04). Because that date is in the future, the floor-IFTE
+returns it unchanged, giving the useful upcoming date. [Materials 21](#materials-21)
 
 
 ## Pluto constants
@@ -2230,12 +2247,15 @@ recurrence of the perihelion passages exposed by `T₀♇`. [Materials 23](#mate
 
 ### T₀♇ constant
 
-Pluto perihelion passage
+Pluto time of perihelion passage
 
-Measured. Pluto's last time of perihelion passage (1989 Sep 05). Pluto's
-orbital period is approximately 248 years. It is the most recent point in
-its orbit when it was closest to the Sun. Next perihelion: ~2237. Value
-in JDN. [Reference 4](#reference-4) [Materials 21](#materials-21)
+Computed, not stored: `T₀♇` evaluates an expression (IFTE) that advances from a
+reference perihelion passage (Tp) by whole orbital periods (`Porb♇`) and returns
+the most recent perihelion passage at or before the current date. The
+computation is carried out in Julian Day Number and converted to a date with
+`JDN→`. Pluto's orbital period is approximately 248 years; the last perihelion
+was in 1989 (Sep 05) and the next is around 2237, so the returned value can be
+decades in the past. [Materials 21](#materials-21)
 
 ## Sun constants
 

--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1725,11 +1725,11 @@ point to the Sun), measured in the direction of motion. [Reference 23](#referenc
 
 Jupiter orbital period
 
-Jupiter's sidereal orbital period — the time to complete one revolution around
-the Sun (about 11.86 years). It is distinct from the rotation period `Prot♃`
-(the ~10 h spin period). Tabulated sidereal value from the NASA Planetary Fact
-Sheet, used as an approximation of the anomalistic period that governs the
-recurrence of the perihelion passages exposed by `T₀♃`. [Materials 23](#materials-23)
+Jupiter's orbital period — the time to complete one revolution around the Sun
+(about 11.86 years). It is distinct from the rotation period `Prot♃` (the ~10 h
+spin period). The value is the anomalistic period (perihelion to perihelion),
+computed from Meeus' Chapter 38, which governs the recurrence of the perihelion
+passages exposed by `T₀♃`. [Materials 22](#materials-22)
 
 ### T₀♃ constant
 
@@ -1854,11 +1854,11 @@ point to the Sun), measured in the direction of motion. [Reference 23](#referenc
 
 Saturn orbital period
 
-Saturn's sidereal orbital period — the time to complete one revolution around
-the Sun (about 29.46 years). It is distinct from the rotation period `Prot♄`
-(the ~10.7 h spin period). Tabulated sidereal value from the NASA Planetary Fact
-Sheet, used as an approximation of the anomalistic period that governs the
-recurrence of the perihelion passages exposed by `T₀♄`. [Materials 23](#materials-23)
+Saturn's orbital period — the time to complete one revolution around the Sun
+(about 29.46 years). It is distinct from the rotation period `Prot♄` (the ~10.7 h
+spin period). The value is the anomalistic period (perihelion to perihelion),
+computed from Meeus' Chapter 38, which governs the recurrence of the perihelion
+passages exposed by `T₀♄`. [Materials 22](#materials-22)
 
 ### T₀♄ constant
 
@@ -1982,11 +1982,11 @@ point to the Sun), measured in the direction of motion. [Reference 23](#referenc
 
 Uranus orbital period
 
-Uranus's sidereal orbital period — the time to complete one revolution around
-the Sun (about 84 years). It is distinct from the rotation period `Prot⛢` (the
-~17 h spin period). Tabulated sidereal value from the NASA Planetary Fact Sheet,
-used as an approximation of the anomalistic period that governs the recurrence
-of the perihelion passages exposed by `T₀⛢`. [Materials 23](#materials-23)
+Uranus's orbital period — the time to complete one revolution around the Sun
+(about 84 years). It is distinct from the rotation period `Prot⛢` (the ~17 h spin
+period). The value is the anomalistic period (perihelion to perihelion), computed
+from Meeus' Chapter 38, which governs the recurrence of the perihelion passages
+exposed by `T₀⛢`. [Materials 22](#materials-22)
 
 ### T₀⛢ constant
 

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1283,7 +1283,7 @@ static const cstring basic_constants[] =
                 "  29.12_° ]",
     // *Mercury time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀☿",      "[ 'JDN→(IFTE((JDN(DateTime)-2461178.915934)/UVAL(CONVERT(ⒸPorb☿;1_d))≥1;2461178.915934+IP((JDN(DateTime)-2461178.915934)/UVAL(CONVERT(ⒸPorb☿;1_d)))*UVAL(CONVERT(ⒸPorb☿;1_d));2461178.915934))' "
-                "  0 0 ]",
+                "  0.0080_d 0 ]",
 
     "Astronomy/Venus",     nullptr,
 
@@ -1362,7 +1362,7 @@ static const cstring basic_constants[] =
                 "  54.88_° ]",
     // *Venus time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀♀",      "[ 'JDN→(IFTE((JDN(DateTime)-2461175.615653)/UVAL(CONVERT(ⒸPorb♀;1_d))≥1;2461175.615653+IP((JDN(DateTime)-2461175.615653)/UVAL(CONVERT(ⒸPorb♀;1_d)))*UVAL(CONVERT(ⒸPorb♀;1_d));2461175.615653))' "
-                "  0 0 ]",
+                "  0.11_d 0 ]",
 
     "Astronomy/Earth",     nullptr,
 
@@ -1438,7 +1438,7 @@ static const cstring basic_constants[] =
                 "  114.2_° ]",
     // *Earth time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀♁",      "[ 'JDN→(IFTE((JDN(DateTime)-2461044.220333)/UVAL(CONVERT(ⒸPorb♁;1_d))≥1;2461044.220333+IP((JDN(DateTime)-2461044.220333)/UVAL(CONVERT(ⒸPorb♁;1_d)))*UVAL(CONVERT(ⒸPorb♁;1_d));2461044.220333))' "
-                "  0 0 ]",
+                "  0.83_d 0 ]",
 
     "Astronomy/Moon",     nullptr,
 
@@ -1590,7 +1590,7 @@ static const cstring basic_constants[] =
                 "  286.5_° ]",
     // *Mars time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀♂",      "[ 'JDN→(IFTE((JDN(DateTime)-2461125.798009)/UVAL(CONVERT(ⒸPorb♂;1_d))≥1;2461125.798009+IP((JDN(DateTime)-2461125.798009)/UVAL(CONVERT(ⒸPorb♂;1_d)))*UVAL(CONVERT(ⒸPorb♂;1_d));2461125.798009))' "
-                "  0 0 ]",
+                "  0.16_d 0 ]",
 
     "Astronomy/Jupiter",     nullptr,
 
@@ -1628,8 +1628,8 @@ static const cstring basic_constants[] =
     "Prot♃",    "[ 35730_s "
                 "  1_s "
                 "  'ROUND(ⓈProt♃/ⒸProt♃;-2)' ]",
-    // *Jupiter orbital period - Sidereal [M23]
-    "Porb♃",    "[ 374335776_s "
+    // *Jupiter orbital period - Computed, anomalistic perigee interval [M22]
+    "Porb♃",    "[ 374360783_s "
                 "  0_s "
                 "  0 ]",
     // *Jupiter axial tilt - Measurement [22]
@@ -1663,7 +1663,7 @@ static const cstring basic_constants[] =
                 "  273.9_° ]",
     // *Jupiter time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀♃",      "[ 'JDN→(IFTE((JDN(DateTime)-2459964.991260)/UVAL(CONVERT(ⒸPorb♃;1_d))≥1;2459964.991260+IP((JDN(DateTime)-2459964.991260)/UVAL(CONVERT(ⒸPorb♃;1_d)))*UVAL(CONVERT(ⒸPorb♃;1_d));2459964.991260))' "
-                "  0 0 ]",
+                "  8.9_d 0 ]",
 
     "Astronomy/Saturn",     nullptr,
 
@@ -1705,8 +1705,8 @@ static const cstring basic_constants[] =
                 "  50_s "
                 "  'ROUND(ⓈProt♄/ⒸProt♄;-2)' "
                 "  3.836E4_s ]",
-    // *Saturn orbital period - Sidereal [M23]
-    "Porb♄",    "[ 929596608_s "
+    // *Saturn orbital period - Computed, anomalistic perigee interval [M22]
+    "Porb♄",    "[ 928565359_s "
                 "  0_s "
                 "  0 ]",
     // *Saturn axial tilt - Measurement [22]
@@ -1740,7 +1740,7 @@ static const cstring basic_constants[] =
                 "  339.4_° ]",
     // *Saturn time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
     "T₀♄",      "[ 'JDN→(IFTE((JDN(DateTime)-2452847.154242)/UVAL(CONVERT(ⒸPorb♄;1_d))≥1;2452847.154242+IP((JDN(DateTime)-2452847.154242)/UVAL(CONVERT(ⒸPorb♄;1_d)))*UVAL(CONVERT(ⒸPorb♄;1_d));2452847.154242))' "
-                "  0 0 ]",
+                "  17_d 0 ]",
 
     "Astronomy/Uranus",     nullptr,
 
@@ -1782,8 +1782,8 @@ static const cstring basic_constants[] =
                 "  10_s "
                 "  'ROUND(ⓈProt⛢/ⒸProt⛢;-2)' "
                 "  6.206E4_s ]",
-    // *Uranus orbital period - Sidereal [M23]
-    "Porb⛢",    "[ 2651486400_s "
+    // *Uranus orbital period - Computed, anomalistic perigee interval [M22]
+    "Porb⛢",    "[ 2658520424_s "
                 "  0_s "
                 "  0 ]",
     // *Uranus axial tilt - Measurement [22]
@@ -1817,7 +1817,7 @@ static const cstring basic_constants[] =
                 "  97.00_° ]",
     // *Uranus time of perihelion passage - Computed via IFTE from Tp and Porb [M22]  (last perihelion 1966; next ~2050)
     "T₀⛢",      "[ 'JDN→(IFTE((JDN(DateTime)-2439264.256742)/UVAL(CONVERT(ⒸPorb⛢;1_d))≥1;2439264.256742+IP((JDN(DateTime)-2439264.256742)/UVAL(CONVERT(ⒸPorb⛢;1_d)))*UVAL(CONVERT(ⒸPorb⛢;1_d));2439264.256742))' "
-                "  0 0 ]",
+                "  40_d 0 ]",
 
     "Astronomy/Neptune",     nullptr,
 
@@ -1893,7 +1893,7 @@ static const cstring basic_constants[] =
                 "  273.2_° ]",
     // *Neptune time of perihelion passage - Computed via IFTE from Tp and Porb [M21]  (EXCEPTION: Tp = next perihelion 2042; floor-IFTE returns it unchanged)
     "T₀♆",      "[ 'JDN→(IFTE((JDN(DateTime)-2467131.5)/UVAL(CONVERT(ⒸPorb♆;1_d))≥1;2467131.5+IP((JDN(DateTime)-2467131.5)/UVAL(CONVERT(ⒸPorb♆;1_d)))*UVAL(CONVERT(ⒸPorb♆;1_d));2467131.5))' "
-                "  0 0 ]",
+                "  10_d 0 ]",
 
     "Astronomy/Pluto",     nullptr,
 
@@ -1970,7 +1970,7 @@ static const cstring basic_constants[] =
                 "  113.8_° ]",
     // *Pluto time of perihelion passage - Computed via IFTE from Tp and Porb [M21]  (last perihelion 1989)
     "T₀♇",      "[ 'JDN→(IFTE((JDN(DateTime)-2447774.5)/UVAL(CONVERT(ⒸPorb♇;1_d))≥1;2447774.5+IP((JDN(DateTime)-2447774.5)/UVAL(CONVERT(ⒸPorb♇;1_d)))*UVAL(CONVERT(ⒸPorb♇;1_d));2447774.5))' "
-                "  0 0 ]",
+                "  5_d 0 ]",
 
     "Astronomy/Sun",     nullptr,
 

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1247,6 +1247,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt☿/ⒸProt☿;-2)' "
                 "  5.067E6_s ]",
+    // *Mercury orbital period - Computed [M22]
+    "Porb☿",    "[ 7600551.8_s "
+                "  0_s "
+                "  0 ]",
     // *Mercury axial tilt - Measurement [22]
     "ϵ☿",       "[ 0.034_° "
                 "  0.001_° "
@@ -1322,6 +1326,10 @@ static const cstring basic_constants[] =
                 "  8.64_s "
                 "  'ROUND(ⓈProt♀/ⒸProt♀;-2)' "
                 "  2.100E7_s ]",
+    // *Venus orbital period - Computed [M22]
+    "Porb♀",    "[ 19414071.4_s "
+                "  0_s "
+                "  0 ]",
     // *Venus axial tilt - Measurement [22]
     "ϵ♀",       "[ 177.36_° "
                 "  0.01_° "
@@ -1395,6 +1403,10 @@ static const cstring basic_constants[] =
                 "  0.0001_s "
                 "  'ROUND(ⓈProt♁/ⒸProt♁;-2)' "
                 "  8.616E4_s ]",
+    // *Earth orbital period - Computed [M22]
+    "Porb♁",    "[ 31558956.5_s "
+                "  0_s "
+                "  0 ]",
     // *Earth axial tilt - Measurement [24]
     "ϵ♁",       "[ 23.4393_° "
                 "  0.0001_° "
@@ -1546,6 +1558,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt♂/ⒸProt♂;-2)' "
                 "  8.864E4_s ]",
+    // *Mars orbital period - Computed [M22]
+    "Porb♂",    "[ 59356065.6_s "
+                "  0_s "
+                "  0 ]",
     // *Mars axial tilt - Measurement [22]
     "ϵ♂",       "[ 25.19_° "
                 "  0.01_° "
@@ -1616,6 +1632,10 @@ static const cstring basic_constants[] =
     "Prot♃",    "[ 35730_s "
                 "  1_s "
                 "  'ROUND(ⓈProt♃/ⒸProt♃;-2)' ]",
+    // *Jupiter orbital period - Sidereal [M23]
+    "Porb♃",    "[ 374335776_s "
+                "  0_s "
+                "  0 ]",
     // *Jupiter axial tilt - Measurement [22]
     "ϵ♃",       "[ 3.13_° "
                 "  0.01_° "
@@ -1690,6 +1710,10 @@ static const cstring basic_constants[] =
                 "  50_s "
                 "  'ROUND(ⓈProt♄/ⒸProt♄;-2)' "
                 "  3.836E4_s ]",
+    // *Saturn orbital period - Sidereal [M23]
+    "Porb♄",    "[ 929596608_s "
+                "  0_s "
+                "  0 ]",
     // *Saturn axial tilt - Measurement [22]
     "ϵ♄",       "[ 26.73_° "
                 "  0.01_° "
@@ -1764,6 +1788,10 @@ static const cstring basic_constants[] =
                 "  10_s "
                 "  'ROUND(ⓈProt⛢/ⒸProt⛢;-2)' "
                 "  6.206E4_s ]",
+    // *Uranus orbital period - Sidereal [M23]
+    "Porb⛢",    "[ 2651486400_s "
+                "  0_s "
+                "  0 ]",
     // *Uranus axial tilt - Measurement [22]
     "ϵ⛢",       "[ 97.77_° "
                 "  0.01_° "
@@ -1837,6 +1865,10 @@ static const cstring basic_constants[] =
     "Prot♆",    "[ 58000_s "
                 "  100_s "
                 "  'ROUND(ⓈProt♆/ⒸProt♆;-2)' ]",
+    // *Neptune orbital period - Sidereal [M23]
+    "Porb♆",    "[ 5200416000_s "
+                "  0_s "
+                "  0 ]",
     // *Neptune axial tilt - Measurement [22]
     "ϵ♆",       "[ 28.32_° "
                 "  0.01_° "
@@ -1910,6 +1942,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt♇/ⒸProt♇;-2)' "
                 "  5.519E5_s ]",
+    // *Pluto orbital period - Sidereal [M23]
+    "Porb♇",    "[ 7824384000_s "
+                "  0_s "
+                "  0 ]",
     // *Pluto axial tilt - Measurement [26]
     "ϵ♇",       "[ 119.591_° "
                 "  0.001_° "

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1281,10 +1281,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω☿/Ⓒω☿;-2)' "
                 "  29.12_° ]",
-    // *Mercury last perihelion passage - Measurement [M20]
-    "T₀☿",      "[ 20260219.4583_date "
-                "  0_date "
-                "  0 ]",
+    // *Mercury time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀☿",      "[ 'JDN→(IFTE((JDN(DateTime)-2461178.915934)/UVAL(CONVERT(ⒸPorb☿;1_d))≥1;2461178.915934+IP((JDN(DateTime)-2461178.915934)/UVAL(CONVERT(ⒸPorb☿;1_d)))*UVAL(CONVERT(ⒸPorb☿;1_d));2461178.915934))' "
+                "  0 0 ]",
 
     "Astronomy/Venus",     nullptr,
 
@@ -1361,10 +1360,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♀/Ⓒω♀;-2)' "
                 "  54.88_° ]",
-    // *Venus next perihelion passage - Measurement [M20]
-    "T₀♀",      "[ 20260515_date "
-                "  0_date "
-                "  0 ]",
+    // *Venus time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀♀",      "[ 'JDN→(IFTE((JDN(DateTime)-2461175.615653)/UVAL(CONVERT(ⒸPorb♀;1_d))≥1;2461175.615653+IP((JDN(DateTime)-2461175.615653)/UVAL(CONVERT(ⒸPorb♀;1_d)))*UVAL(CONVERT(ⒸPorb♀;1_d));2461175.615653))' "
+                "  0 0 ]",
 
     "Astronomy/Earth",     nullptr,
 
@@ -1438,10 +1436,9 @@ static const cstring basic_constants[] =
                 "  0.00001_° "
                 "  'ROUND(Ⓢω♁/Ⓒω♁;-2)' "
                 "  114.2_° ]",
-    // *Earth perihelion passage - Measurement [M20]
-    "T₀♁",      "[ 20260103.7188_date "
-                "  0_date "
-                "  0 ]",
+    // *Earth time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀♁",      "[ 'JDN→(IFTE((JDN(DateTime)-2461044.220333)/UVAL(CONVERT(ⒸPorb♁;1_d))≥1;2461044.220333+IP((JDN(DateTime)-2461044.220333)/UVAL(CONVERT(ⒸPorb♁;1_d)))*UVAL(CONVERT(ⒸPorb♁;1_d));2461044.220333))' "
+                "  0 0 ]",
 
     "Astronomy/Moon",     nullptr,
 
@@ -1591,10 +1588,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♂/Ⓒω♂;-2)' "
                 "  286.5_° ]",
-    // *Mars perihelion passage - Measurement [M20]
-    "T₀♂",      "[ 20260326_date "
-                "  0_date "
-                "  0 ]",
+    // *Mars time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀♂",      "[ 'JDN→(IFTE((JDN(DateTime)-2461125.798009)/UVAL(CONVERT(ⒸPorb♂;1_d))≥1;2461125.798009+IP((JDN(DateTime)-2461125.798009)/UVAL(CONVERT(ⒸPorb♂;1_d)))*UVAL(CONVERT(ⒸPorb♂;1_d));2461125.798009))' "
+                "  0 0 ]",
 
     "Astronomy/Jupiter",     nullptr,
 
@@ -1665,10 +1661,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♃/Ⓒω♃;-2)' "
                 "  273.9_° ]",
-    // *Jupiter perihelion passage - Measurement [4] [M21]
-    "T₀♃",      "[ 20230120_date "
-                "  0_date "
-                "  0 ]",
+    // *Jupiter time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀♃",      "[ 'JDN→(IFTE((JDN(DateTime)-2459964.991260)/UVAL(CONVERT(ⒸPorb♃;1_d))≥1;2459964.991260+IP((JDN(DateTime)-2459964.991260)/UVAL(CONVERT(ⒸPorb♃;1_d)))*UVAL(CONVERT(ⒸPorb♃;1_d));2459964.991260))' "
+                "  0 0 ]",
 
     "Astronomy/Saturn",     nullptr,
 
@@ -1743,10 +1738,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♄/Ⓒω♄;-2)' "
                 "  339.4_° ]",
-    // *Saturn perihelion passage - Measurement [4] [M21]
-    "T₀♄",      "[ 20030726_date "
-                "  0_date "
-                "  0 ]",
+    // *Saturn time of perihelion passage - Computed via IFTE from Tp and Porb [M22]
+    "T₀♄",      "[ 'JDN→(IFTE((JDN(DateTime)-2452847.154242)/UVAL(CONVERT(ⒸPorb♄;1_d))≥1;2452847.154242+IP((JDN(DateTime)-2452847.154242)/UVAL(CONVERT(ⒸPorb♄;1_d)))*UVAL(CONVERT(ⒸPorb♄;1_d));2452847.154242))' "
+                "  0 0 ]",
 
     "Astronomy/Uranus",     nullptr,
 
@@ -1821,10 +1815,9 @@ static const cstring basic_constants[] =
                 "  0.000001_° "
                 "  'ROUND(Ⓢω⛢/Ⓒω⛢;-2)' "
                 "  97.00_° ]",
-    // *Uranus perihelion passage - Calculation from measurement [4] [M21]
-    "T₀⛢",      "[ 20500816_date "
-                "  0_date "
-                "  0 ]",
+    // *Uranus time of perihelion passage - Computed via IFTE from Tp and Porb [M22]  (last perihelion 1966; next ~2050)
+    "T₀⛢",      "[ 'JDN→(IFTE((JDN(DateTime)-2439264.256742)/UVAL(CONVERT(ⒸPorb⛢;1_d))≥1;2439264.256742+IP((JDN(DateTime)-2439264.256742)/UVAL(CONVERT(ⒸPorb⛢;1_d)))*UVAL(CONVERT(ⒸPorb⛢;1_d));2439264.256742))' "
+                "  0 0 ]",
 
     "Astronomy/Neptune",     nullptr,
 
@@ -1898,10 +1891,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♆/Ⓒω♆;-2)' "
                 "  273.2_° ]",
-    // *Neptune perihelion passage - Calculation from measurement [4] [M21]
-    "T₀♆",      "[ 20420904_date "
-                "  0_date "
-                "  0 ]",
+    // *Neptune time of perihelion passage - Computed via IFTE from Tp and Porb [M21]  (EXCEPTION: Tp = next perihelion 2042; floor-IFTE returns it unchanged)
+    "T₀♆",      "[ 'JDN→(IFTE((JDN(DateTime)-2467131.5)/UVAL(CONVERT(ⒸPorb♆;1_d))≥1;2467131.5+IP((JDN(DateTime)-2467131.5)/UVAL(CONVERT(ⒸPorb♆;1_d)))*UVAL(CONVERT(ⒸPorb♆;1_d));2467131.5))' "
+                "  0 0 ]",
 
     "Astronomy/Pluto",     nullptr,
 
@@ -1976,10 +1968,9 @@ static const cstring basic_constants[] =
                 "  0.001_° "
                 "  'ROUND(Ⓢω♇/Ⓒω♇;-2)' "
                 "  113.8_° ]",
-    // *Pluto perihelion passage - Measurement [4] [M21]
-    "T₀♇",      "[ 19890905_date "
-                "  0_date "
-                "  0 ]",
+    // *Pluto time of perihelion passage - Computed via IFTE from Tp and Porb [M21]  (last perihelion 1989)
+    "T₀♇",      "[ 'JDN→(IFTE((JDN(DateTime)-2447774.5)/UVAL(CONVERT(ⒸPorb♇;1_d))≥1;2447774.5+IP((JDN(DateTime)-2447774.5)/UVAL(CONVERT(ⒸPorb♇;1_d)))*UVAL(CONVERT(ⒸPorb♇;1_d));2447774.5))' "
+                "  0 0 ]",
 
     "Astronomy/Sun",     nullptr,
 


### PR DESCRIPTION
constants: Planetary orbital periods (Porb) and live perihelion T₀ (IFTE)

  A1. Add Porb (orbital period, _s) for the 9 PLANETS, after each Prot.
      Absolute uncertainty 0. Same commit: matching constants.md (refs M38/PFS).
  A2. Replace each planet T0 with the IFTE seeded by Tp, output _date via
      JDN→ (operator confirmed). One parameterized formula, not nine; reads
      ⒸPorb. Same commit: matching constants.md (refs M38/EPH) + the Neptune
      convention note. Depends on A1 (clean form reads Porb).

      NOTE: any constants.md wording fix that belongs with these changes (e.g.
      distinguishing Porb=orbital from Prot=rotation) goes INSIDE A1/A2 — doc
      travels with code, no separate doc-only commit.
