### PR TITLE
Pr c completeness

### DIFF
--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -994,6 +994,14 @@ Mercury gravitational parameter
 
 It is measured by radio tracking of spacecraft (Mariner 10, MESSENGER). [Reference 4](#reference-4)
 
+### M☿ constant
+
+Mercury mass
+
+Mercury's mass, derived from the gravitational parameter `GM☿` and the measured
+gravitational constant `G` as `GM☿/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req☿ constant
 
 Mercury equatorial radius
@@ -1110,6 +1118,14 @@ Venus gravitational parameter
 Venus's gravitational parameter, measured by radio tracking of spacecraft
 (Magellan, Venus Express). [Reference 4](#reference-4)
 
+### M♀ constant
+
+Venus mass
+
+Venus's mass, derived from the gravitational parameter `GM♀` and the measured
+gravitational constant `G` as `GM♀/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req♀ constant
 
 Venus equatorial radius
@@ -1222,6 +1238,14 @@ Earth gravitational parameter
 
 Exact nominal value (IAU 2015). Earth's gravitational parameter. An exact nominal
 value defined by the IAU (2015). [Particle Data Group 2023](#particle-data-group-2023)
+
+### M♁ constant
+
+Earth mass
+
+Earth's mass, derived from the gravitational parameter `GM♁` and the measured
+gravitational constant `G` as `GM♁/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Particle Data Group 2023](#particle-data-group-2023) [Reference 5](#reference-5)
 
 ### Req♁ constant
 
@@ -1342,6 +1366,14 @@ Moon gravitational parameter
 Measured. Moon's gravitational parameter, measured by lunar laser ranging
 and spacecraft radio tracking. [Reference 4](#reference-4)
 
+### M☽ constant
+
+Moon mass
+
+The Moon's mass, derived from the gravitational parameter `GM☽` and the measured
+gravitational constant `G` as `GM☽/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req☽ constant
 
 Moon equatorial radius
@@ -1458,6 +1490,14 @@ Mars gravitational parameter
 Measured. Mars system gravitational parameter, including the contribution of
 its moons Phobos and Deimos, measured by spacecraft radio tracking. [Reference 4](#reference-4)
 
+### M♂ constant
+
+Mars mass
+
+Mars's mass, derived from the gravitational parameter `GM♂` and the measured
+gravitational constant `G` as `GM♂/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req♂ constant
 
 Mars equatorial radius
@@ -1569,6 +1609,14 @@ Jupiter gravitational parameter
 
 Exact nominal value (IAU 2015). Jupiter system gravitational parameter.
 An exact nominal value defined by the IAU (2015). [Particle Data Group 2023](#particle-data-group-2023)
+
+### M♃ constant
+
+Jupiter mass
+
+Jupiter's mass, derived from the gravitational parameter `GM♃` and the measured
+gravitational constant `G` as `GM♃/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Particle Data Group 2023](#particle-data-group-2023) [Reference 5](#reference-5)
 
 ### Req♃ constant
 
@@ -1688,6 +1736,14 @@ Saturn gravitational parameter
 Measured. Saturn system gravitational parameter, measured by radio
 tracking of the Cassini spacecraft. [Reference 4](#reference-4)
 
+### M♄ constant
+
+Saturn mass
+
+Saturn's mass, derived from the gravitational parameter `GM♄` and the measured
+gravitational constant `G` as `GM♄/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req♄ constant
 
 Saturn equatorial radius
@@ -1804,6 +1860,14 @@ Uranus gravitational parameter
 
 Measured. Uranus system gravitational parameter, measured by Voyager
 2 radio tracking. [Reference 4](#reference-4)
+
+### M⛢ constant
+
+Uranus mass
+
+Uranus's mass, derived from the gravitational parameter `GM⛢` and the measured
+gravitational constant `G` as `GM⛢/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
 
 ### Req⛢ constant
 
@@ -1923,6 +1987,14 @@ Neptune gravitational parameter
 Measured. Neptune system gravitational parameter, measured by Voyager
 2 radio tracking and Hubble Space Telescope astrometry of Triton. [Reference 4](#reference-4)
 
+### M♆ constant
+
+Neptune mass
+
+Neptune's mass, derived from the gravitational parameter `GM♆` and the measured
+gravitational constant `G` as `GM♆/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
+
 ### Req♆ constant
 
 Neptune equatorial radius
@@ -2039,6 +2111,14 @@ Pluto gravitational parameter
 
 Measured. Pluto system gravitational parameter, measured by New Horizons
 radio tracking. [Reference 4](#reference-4)
+
+### M♇ constant
+
+Pluto mass
+
+Pluto's mass, derived from the gravitational parameter `GM♇` and the measured
+gravitational constant `G` as `GM♇/G`. The relative uncertainty is carried as
+`ⓇG` (the dominant term), so the mass self-corrects whenever `G` is updated. [Reference 4](#reference-4) [Reference 5](#reference-5)
 
 ### Req♇ constant
 

--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1380,6 +1380,74 @@ year). Value in JDN. It is the most recent point in its orbit when it was
 closest to the Sun. [Materials 20](#materials-20)
 
 
+### a♁GPS constant
+
+Earth equatorial radius (WGS-84)
+
+The semi-major axis of the WGS-84 reference ellipsoid, a defining constant of the
+World Geodetic System 1984 used by GPS. Exact by definition. [WGS-84](#wgs-84)
+
+### f♁GPS constant
+
+Earth flattening (WGS-84)
+
+The flattening of the WGS-84 reference ellipsoid, `1/298.257223563`, a defining
+constant. Exact by definition. [WGS-84](#wgs-84)
+
+### ω♁GPS constant
+
+Earth nominal mean angular velocity (WGS-84)
+
+The nominal mean angular velocity of the Earth in the WGS-84 system. Exact by
+definition, and distinct from the sidereal value `ωrot♁` derived from `Prot♁`. [WGS-84](#wgs-84)
+
+### GM♁GPS constant
+
+Earth gravitational parameter (WGS-84)
+
+The geocentric gravitational constant of the WGS-84 system, including the mass of
+the Earth's atmosphere. Exact by definition, and distinct from the IAU nominal
+`GM♁`. [WGS-84](#wgs-84)
+
+### e²♁GPS constant
+
+Earth first eccentricity squared (WGS-84)
+
+The square of the first eccentricity of the WGS-84 reference ellipsoid, computed
+from the flattening as `2·f♁GPS−f♁GPS²`. This is an ellipsoid (shape) eccentricity,
+not the orbital eccentricity `e♁`. [WGS-84](#wgs-84)
+
+### e'²♁GPS constant
+
+Earth second eccentricity squared (WGS-84)
+
+The square of the second eccentricity of the WGS-84 reference ellipsoid, computed
+from the first as `e²♁GPS/(1−e²♁GPS)`. An ellipsoid eccentricity, distinct from the
+orbital eccentricity `e♁`. [WGS-84](#wgs-84)
+
+### Ytrop♁ constant
+
+Tropical year
+
+The tropical (seasonal) year, equinox to equinox, about 365.24219 days at J2000.
+It is distinct from `Porb♁` (the anomalistic year, perihelion to perihelion, used
+by `T₀♁`) and from the calendar years `YJul♁` and `YGreg♁`. [Reference 24](#reference-24)
+
+### YJul♁ constant
+
+Julian year
+
+The Julian year, exactly 365.25 days. It is the year used to define the
+light-year. [Reference 24](#reference-24)
+
+### YGreg♁ constant
+
+Gregorian mean year
+
+The mean year of the Gregorian calendar, exactly 365.2425 days
+(365 + 1/4 − 1/100 + 1/400). [Reference 24](#reference-24)
+
+
 ## Moon constants
 
 ### GM☽ constant
@@ -3483,6 +3551,10 @@ Particle Data Group (2024). "Review of Particle Physics — Astrophysical Consta
 ### Particle Data Group 2023
 
 Particle Data Group 2023 Prša, A., et al. (2016). "Nominal values for selected solar and planetary quantities: IAU 2015 Resolution B3". The Astronomical Journal, 152(2), 41. arXiv:1605.09788 — DOI: 10.3847/0004-6256/152/2/41
+
+### WGS-84
+
+National Geospatial-Intelligence Agency (2014). Department of Defense World Geodetic System 1984: Its Definition and Relationships with Local Geodetic Systems, NGA.STND.0036_1.0.0_WGS84, 3rd ed. (Defining parameters of the WGS-84 reference ellipsoid used by GPS.)
 
 ### Reference 4
 

--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1409,7 +1409,7 @@ The geocentric gravitational constant of the WGS-84 system, including the mass o
 the Earth's atmosphere. Exact by definition, and distinct from the IAU nominal
 `GM♁`. [WGS-84](#wgs-84)
 
-### e²♁GPS constant
+### e12♁GPS constant
 
 Earth first eccentricity squared (WGS-84)
 
@@ -1417,13 +1417,13 @@ The square of the first eccentricity of the WGS-84 reference ellipsoid, computed
 from the flattening as `2·f♁GPS−f♁GPS²`. This is an ellipsoid (shape) eccentricity,
 not the orbital eccentricity `e♁`. [WGS-84](#wgs-84)
 
-### e'²♁GPS constant
+### e22♁GPS constant
 
 Earth second eccentricity squared (WGS-84)
 
 The square of the second eccentricity of the WGS-84 reference ellipsoid, computed
-from the first as `e²♁GPS/(1−e²♁GPS)`. An ellipsoid eccentricity, distinct from the
-orbital eccentricity `e♁`. [WGS-84](#wgs-84)
+from the first as `e12♁GPS/(1−e12♁GPS)`. An ellipsoid eccentricity, distinct from
+the orbital eccentricity `e♁`. [WGS-84](#wgs-84)
 
 ### Ytrop♁ constant
 

--- a/doc/calc-help/constants.md
+++ b/doc/calc-help/constants.md
@@ -1052,6 +1052,13 @@ Mercury's sidereal rotation period is a measured quantity. It is the true time
 it takes to spin 360° on its axis. Mercury is in a 3:2 spin-orbit resonance with
 the Sun, rotating three times for every two orbits. [Reference 22](#reference-22)
 
+### ωrot☿ constant
+
+Mercury rotation angular velocity
+
+Mercury's sidereal rotation angular velocity, computed as `2π/Prot☿` from the
+sidereal rotation period. The unit is radians per second (`r/s`). [Reference 22](#reference-22)
+
 ### ϵ☿ constant
 
 Mercury axial tilt
@@ -1177,6 +1184,15 @@ Measured. Venus's sidereal rotation period is the true time it takes to spin 360
 on its axis. Venus rotates retrograde (opposite to its orbital motion), with a
 rotation period longer than its orbital period. [Reference 22](#reference-22)
 
+### ωrot♀ constant
+
+Venus rotation angular velocity
+
+Venus's sidereal rotation angular velocity, computed as `2π/Prot♀` from the
+sidereal rotation period. The value is negative because Venus rotates retrograde
+(opposite to its orbital motion); the uncertainty uses the positive magnitude.
+The unit is radians per second (`r/s`). [Reference 22](#reference-22)
+
 ### ϵ♀ constant
 
 Venus axial tilt
@@ -1297,6 +1313,13 @@ Earth sidereal rotation period
 
 Measured. Earth's sidereal rotation period (one sidereal day), the time for one
 rotation relative to the fixed stars. [Reference 24](#reference-24)
+
+### ωrot♁ constant
+
+Earth rotation angular velocity
+
+Earth's sidereal rotation angular velocity, computed as `2π/Prot♁` from the
+sidereal rotation period. The unit is radians per second (`r/s`). [Reference 24](#reference-24)
 
 ### ϵ♁ constant
 
@@ -1425,6 +1448,14 @@ Measured. Moon's sidereal rotation period is the true time it takes to spin
 360° on its axis. The Moon is tidally locked to Earth, so its rotation period
 equals its orbital period. [Reference 22](#reference-22)
 
+### ωrot☽ constant
+
+Moon rotation angular velocity
+
+The Moon's sidereal rotation angular velocity, computed as `2π/Prot☽` from the
+sidereal rotation period. Because the Moon is tidally locked, this equals its
+orbital mean motion. The unit is radians per second (`r/s`). [Reference 22](#reference-22)
+
 ### ϵ☽ constant
 
 Moon axial tilt
@@ -1546,6 +1577,13 @@ Mars sidereal rotation period
 Measured. Mars's sidereal rotation period is the true time it takes to spin
 360° on its axis. A Martian day (sol) is very similar in length to an Earth day.
 [Reference 22](#reference-22)
+
+### ωrot♂ constant
+
+Mars rotation angular velocity
+
+Mars's sidereal rotation angular velocity, computed as `2π/Prot♂` from the
+sidereal rotation period. The unit is radians per second (`r/s`). [Reference 22](#reference-22)
 
 ### ϵ♂ constant
 
@@ -1670,6 +1708,13 @@ Jupiter sidereal rotation period
 Measured. Jupiter's sidereal rotation period is the true time it takes to
 spin 360° on its axis (System III, based on radio emissions from its
 magnetosphere). [Reference 22](#reference-22)
+
+### ωrot♃ constant
+
+Jupiter rotation angular velocity
+
+Jupiter's sidereal rotation angular velocity, computed as `2π/Prot♃` from the
+sidereal rotation period (System III). The unit is radians per second (`r/s`). [Reference 22](#reference-22)
 
 ### ϵ♃ constant
 
@@ -1796,6 +1841,13 @@ Measured. Saturn's sidereal rotation period is the true time it takes
 to spin 360° on its axis (System III, based on Cassini radio
 measurements). [Reference 22](#reference-22)
 
+### ωrot♄ constant
+
+Saturn rotation angular velocity
+
+Saturn's sidereal rotation angular velocity, computed as `2π/Prot♄` from the
+sidereal rotation period (System III). The unit is radians per second (`r/s`). [Reference 22](#reference-22)
+
 ### ϵ♄ constant
 
 Saturn axial tilt
@@ -1919,6 +1971,15 @@ Uranus sidereal rotation period
 Measured. Uranus's sidereal rotation period is the true time it takes
 to spin 360° on its axis. Uranus rotates retrograde relative to its
 orbital motion. [Reference 22](#reference-22)
+
+### ωrot⛢ constant
+
+Uranus rotation angular velocity
+
+Uranus's sidereal rotation angular velocity, computed as `2π/Prot⛢` from the
+sidereal rotation period. The value is negative because Uranus rotates retrograde
+relative to its orbital motion; the uncertainty uses the positive magnitude. The
+unit is radians per second (`r/s`). [Reference 22](#reference-22)
 
 ### ϵ⛢ constant
 
@@ -2046,6 +2107,13 @@ Measured. Neptune's sidereal rotation period is the true time it takes
 to spin 360° on its axis (System III, from Voyager 2 radio measurements).
 [Reference 22](#reference-22)
 
+### ωrot♆ constant
+
+Neptune rotation angular velocity
+
+Neptune's sidereal rotation angular velocity, computed as `2π/Prot♆` from the
+sidereal rotation period (System III). The unit is radians per second (`r/s`). [Reference 22](#reference-22)
+
 ### ϵ♆ constant
 
 Neptune axial tilt
@@ -2168,6 +2236,15 @@ Pluto sidereal rotation period
 Measured. Pluto's sidereal rotation period is the true time it takes to
 spin 360° on its axis. Pluto rotates retrograde and is tidally locked to
 its moon Charon. [Reference 26](#reference-26)
+
+### ωrot♇ constant
+
+Pluto rotation angular velocity
+
+Pluto's sidereal rotation angular velocity, computed as `2π/Prot♇` from the
+sidereal rotation period. The value is negative because Pluto rotates retrograde;
+the uncertainty uses the positive magnitude. The unit is radians per second
+(`r/s`). [Reference 26](#reference-26)
 
 ### ϵ♇ constant
 
@@ -2299,6 +2376,14 @@ The Solar sidereal rotation period at the equator (System I) is measured
 by tracking surface features using Doppler techniques. It is the true
 time it takes to spin 360° on its axis. [Reference 20](#reference-20) [Reference 21](#reference-21)
 
+
+### ωrot☉ constant
+
+Solar rotation angular velocity
+
+The Sun's sidereal rotation angular velocity at the equator (System I), computed
+as `2π/Prot☉` from the sidereal rotation period. The unit is radians per second
+(`r/s`). [Reference 20](#reference-20) [Reference 21](#reference-21)
 
 ## Cosmology constants
 

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1252,6 +1252,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt☿/ⒸProt☿;-2)' "
                 "  5.067E6_s ]",
+    // *Mercury rotation angular velocity - Calculation from Prot
+    "ωrot☿",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☿;1_r/s);XPON(UVAL(Ⓡωrot☿*2*Ⓒπ/ⒸProt☿))-XPON(UVAL(2*Ⓒπ/ⒸProt☿))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☿*2*Ⓒπ/ⒸProt☿);-2);1_r/s)' "
+                "  'ⓇProt☿' ]",
     // *Mercury axial tilt - Measurement [22]
     "ϵ☿",       "[ 0.034_° "
                 "  0.001_° "
@@ -1332,6 +1336,10 @@ static const cstring basic_constants[] =
                 "  8.64_s "
                 "  'ROUND(ⓈProt♀/ⒸProt♀;-2)' "
                 "  2.100E7_s ]",
+    // *Venus rotation angular velocity - Calculation from Prot  [retrograde]
+    "ωrot♀",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt♀;1_r/s);XPON(UVAL(Ⓡωrot♀*2*Ⓒπ/ⒸProt♀))-XPON(UVAL(2*Ⓒπ/ⒸProt♀))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♀*2*Ⓒπ/ⒸProt♀);-2);1_r/s)' "
+                "  'ⓇProt♀' ]",
     // *Venus axial tilt - Measurement [22]
     "ϵ♀",       "[ 177.36_° "
                 "  0.01_° "
@@ -1410,6 +1418,10 @@ static const cstring basic_constants[] =
                 "  0.0001_s "
                 "  'ROUND(ⓈProt♁/ⒸProt♁;-2)' "
                 "  8.616E4_s ]",
+    // *Earth rotation angular velocity - Calculation from Prot
+    "ωrot♁",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♁;1_r/s);XPON(UVAL(Ⓡωrot♁*2*Ⓒπ/ⒸProt♁))-XPON(UVAL(2*Ⓒπ/ⒸProt♁))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♁*2*Ⓒπ/ⒸProt♁);-2);1_r/s)' "
+                "  'ⓇProt♁' ]",
     // *Earth axial tilt - Measurement [24]
     "ϵ♁",       "[ 23.4393_° "
                 "  0.0001_° "
@@ -1491,6 +1503,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt☽/ⒸProt☽;-2)' "
                 "  2.361E6_s ]",
+    // *Moon rotation angular velocity - Calculation from Prot
+    "ωrot☽",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☽;1_r/s);XPON(UVAL(Ⓡωrot☽*2*Ⓒπ/ⒸProt☽))-XPON(UVAL(2*Ⓒπ/ⒸProt☽))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☽*2*Ⓒπ/ⒸProt☽);-2);1_r/s)' "
+                "  'ⓇProt☽' ]",
     // *Moon axial tilt - Measurement [22]
     "ϵ☽",       "[ 1.5424_° "
                 "  0.0001_° "
@@ -1571,6 +1587,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt♂/ⒸProt♂;-2)' "
                 "  8.864E4_s ]",
+    // *Mars rotation angular velocity - Calculation from Prot
+    "ωrot♂",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♂;1_r/s);XPON(UVAL(Ⓡωrot♂*2*Ⓒπ/ⒸProt♂))-XPON(UVAL(2*Ⓒπ/ⒸProt♂))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♂*2*Ⓒπ/ⒸProt♂);-2);1_r/s)' "
+                "  'ⓇProt♂' ]",
     // *Mars axial tilt - Measurement [22]
     "ϵ♂",       "[ 25.19_° "
                 "  0.01_° "
@@ -1646,6 +1666,10 @@ static const cstring basic_constants[] =
     "Prot♃",    "[ 35730_s "
                 "  1_s "
                 "  'ROUND(ⓈProt♃/ⒸProt♃;-2)' ]",
+    // *Jupiter rotation angular velocity - Calculation from Prot
+    "ωrot♃",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♃;1_r/s);XPON(UVAL(Ⓡωrot♃*2*Ⓒπ/ⒸProt♃))-XPON(UVAL(2*Ⓒπ/ⒸProt♃))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♃*2*Ⓒπ/ⒸProt♃);-2);1_r/s)' "
+                "  'ⓇProt♃' ]",
     // *Jupiter axial tilt - Measurement [22]
     "ϵ♃",       "[ 3.13_° "
                 "  0.01_° "
@@ -1725,6 +1749,10 @@ static const cstring basic_constants[] =
                 "  50_s "
                 "  'ROUND(ⓈProt♄/ⒸProt♄;-2)' "
                 "  3.836E4_s ]",
+    // *Saturn rotation angular velocity - Calculation from Prot
+    "ωrot♄",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♄;1_r/s);XPON(UVAL(Ⓡωrot♄*2*Ⓒπ/ⒸProt♄))-XPON(UVAL(2*Ⓒπ/ⒸProt♄))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♄*2*Ⓒπ/ⒸProt♄);-2);1_r/s)' "
+                "  'ⓇProt♄' ]",
     // *Saturn axial tilt - Measurement [22]
     "ϵ♄",       "[ 26.73_° "
                 "  0.01_° "
@@ -1804,6 +1832,10 @@ static const cstring basic_constants[] =
                 "  10_s "
                 "  'ROUND(ⓈProt⛢/ⒸProt⛢;-2)' "
                 "  6.206E4_s ]",
+    // *Uranus rotation angular velocity - Calculation from Prot  [retrograde]
+    "ωrot⛢",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt⛢;1_r/s);XPON(UVAL(Ⓡωrot⛢*2*Ⓒπ/ⒸProt⛢))-XPON(UVAL(2*Ⓒπ/ⒸProt⛢))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot⛢*2*Ⓒπ/ⒸProt⛢);-2);1_r/s)' "
+                "  'ⓇProt⛢' ]",
     // *Uranus axial tilt - Measurement [22]
     "ϵ⛢",       "[ 97.77_° "
                 "  0.01_° "
@@ -1882,6 +1914,10 @@ static const cstring basic_constants[] =
     "Prot♆",    "[ 58000_s "
                 "  100_s "
                 "  'ROUND(ⓈProt♆/ⒸProt♆;-2)' ]",
+    // *Neptune rotation angular velocity - Calculation from Prot
+    "ωrot♆",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♆;1_r/s);XPON(UVAL(Ⓡωrot♆*2*Ⓒπ/ⒸProt♆))-XPON(UVAL(2*Ⓒπ/ⒸProt♆))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♆*2*Ⓒπ/ⒸProt♆);-2);1_r/s)' "
+                "  'ⓇProt♆' ]",
     // *Neptune axial tilt - Measurement [22]
     "ϵ♆",       "[ 28.32_° "
                 "  0.01_° "
@@ -1960,6 +1996,10 @@ static const cstring basic_constants[] =
                 "  0.1_s "
                 "  'ROUND(ⓈProt♇/ⒸProt♇;-2)' "
                 "  5.519E5_s ]",
+    // *Pluto rotation angular velocity - Calculation from Prot  [retrograde]
+    "ωrot♇",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt♇;1_r/s);XPON(UVAL(Ⓡωrot♇*2*Ⓒπ/ⒸProt♇))-XPON(UVAL(2*Ⓒπ/ⒸProt♇))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♇*2*Ⓒπ/ⒸProt♇);-2);1_r/s)' "
+                "  'ⓇProt♇' ]",
     // *Pluto axial tilt - Measurement [26]
     "ϵ♇",       "[ 119.591_° "
                 "  0.001_° "
@@ -2042,6 +2082,10 @@ static const cstring basic_constants[] =
                 "  864_s "
                 "  'ROUND(ⓈProt☉/ⒸProt☉;-2)' "
                 "  2.193E6_s ]",
+    // *Sun rotation angular velocity - Calculation from Prot
+    "ωrot☉",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☉;1_r/s);XPON(UVAL(Ⓡωrot☉*2*Ⓒπ/ⒸProt☉))-XPON(UVAL(2*Ⓒπ/ⒸProt☉))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☉*2*Ⓒπ/ⒸProt☉);-2);1_r/s)' "
+                "  'ⓇProt☉' ]",
 
     "Astronomy/Cosmology",     nullptr,
 

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1214,6 +1214,11 @@ static const cstring basic_constants[] =
                 "  0.0000000091E13_m³/s² "
                 "  'ROUND(ⓈGM☿/ⒸGM☿;-2)' "
                 "  2.203E13_m³/s² ]",
+    // *Mercury mass - Calculation from GM and G
+    "M☿",       "[ 'ROUND(CONVERT(ⒸGM☿/ⒸG;1_kg);XPON(UVAL(ⒸGM☿/ⒸG·ⓇG))-XPON(UVAL(ⒸGM☿/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM☿*ⒸM☿);-2);1_kg)' "
+                "  'ⓇG' "
+                "  3.301E23_kg ]",
     // *Mercury equatorial radius - Measurement [22]
     "Req☿",     "[ 2439.7_km "
                 "  0.1_km "
@@ -1289,6 +1294,11 @@ static const cstring basic_constants[] =
                 "  0.00000012E14_m³/s² "
                 "  'ROUND(ⓈGM♀/ⒸGM♀;-2)' "
                 "  3.249E14_m³/s² ]",
+    // *Venus mass - Calculation from GM and G
+    "M♀",       "[ 'ROUND(CONVERT(ⒸGM♀/ⒸG;1_kg);XPON(UVAL(ⒸGM♀/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♀/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♀*ⒸM♀);-2);1_kg)' "
+                "  'ⓇG' "
+                "  4.867E24_kg ]",
     // *Venus equatorial radius - Measurement [22]
     "Req♀",     "[ 6051.8_km "
                 "  0.1_km "
@@ -1364,6 +1374,11 @@ static const cstring basic_constants[] =
     "GM♁",      "[ 3.986004E14_m³/s² "
                 "  0_m³/s² "
                 "  0 ]",
+    // *Earth mass - Calculation from GM and G
+    "M♁",       "[ 'ROUND(CONVERT(ⒸGM♁/ⒸG;1_kg);XPON(UVAL(ⒸGM♁/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♁/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♁*ⒸM♁);-2);1_kg)' "
+                "  'ⓇG' "
+                "  5.972E24_kg ]",
     // *Earth equatorial radius - Exact nominal value [3]
     "Req♁",     "[ 6378.1_km "
                 "  0_km "
@@ -1438,6 +1453,11 @@ static const cstring basic_constants[] =
                 "  0.0000000009E12_m³/s² "
                 "  'ROUND(ⓈGM☽/ⒸGM☽;-2)' "
                 "  4.903E12_m³/s² ]",
+    // *Moon mass - Calculation from GM and G
+    "M☽",       "[ 'ROUND(CONVERT(ⒸGM☽/ⒸG;1_kg);XPON(UVAL(ⒸGM☽/ⒸG·ⓇG))-XPON(UVAL(ⒸGM☽/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM☽*ⒸM☽);-2);1_kg)' "
+                "  'ⓇG' "
+                "  7.346E22_kg ]",
     // *Moon equatorial radius - Measurement [22]
     "Req☽",     "[ 1738.1_km "
                 "  0.1_km "
@@ -1513,6 +1533,11 @@ static const cstring basic_constants[] =
                 "  0.00000000091E13_m³/s² "
                 "  'ROUND(ⓈGM♂/ⒸGM♂;-2)' "
                 "  4.283E13_m³/s² ]",
+    // *Mars mass - Calculation from GM and G
+    "M♂",       "[ 'ROUND(CONVERT(ⒸGM♂/ⒸG;1_kg);XPON(UVAL(ⒸGM♂/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♂/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♂*ⒸM♂);-2);1_kg)' "
+                "  'ⓇG' "
+                "  6.417E23_kg ]",
     // *Mars equatorial radius - Measurement [22]
     "Req♂",     "[ 3396.2_km "
                 "  0.1_km "
@@ -1586,6 +1611,11 @@ static const cstring basic_constants[] =
     "GM♃",      "[ 1.26686534E17_m³/s² "
                 "  0_m³/s² "
                 "  0 ]",
+    // *Jupiter mass - Calculation from GM and G
+    "M♃",       "[ 'ROUND(CONVERT(ⒸGM♃/ⒸG;1_kg);XPON(UVAL(ⒸGM♃/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♃/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♃*ⒸM♃);-2);1_kg)' "
+                "  'ⓇG' "
+                "  1.898E27_kg ]",
     // *Jupiter equatorial radius - Exact nominal value [3]
     "Req♃",     "[ 71492_km "
                 "  0_km "
@@ -1657,6 +1687,11 @@ static const cstring basic_constants[] =
                 "  0.00000000091E16_m³/s² "
                 "  'ROUND(ⓈGM♄/ⒸGM♄;-2)' "
                 "  3.794E16_m³/s² ]",
+    // *Saturn mass - Calculation from GM and G
+    "M♄",       "[ 'ROUND(CONVERT(ⒸGM♄/ⒸG;1_kg);XPON(UVAL(ⒸGM♄/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♄/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♄*ⒸM♄);-2);1_kg)' "
+                "  'ⓇG' "
+                "  5.685E26_kg ]",
     // *Saturn equatorial radius - Measurement [22]
     "Req♄",     "[ 60268_km "
                 "  4_km "
@@ -1731,6 +1766,11 @@ static const cstring basic_constants[] =
                 "  0.0000040E15_m³/s² "
                 "  'ROUND(ⓈGM⛢/ⒸGM⛢;-2)' "
                 "  5.795E15_m³/s² ]",
+    // *Uranus mass - Calculation from GM and G
+    "M⛢",       "[ 'ROUND(CONVERT(ⒸGM⛢/ⒸG;1_kg);XPON(UVAL(ⒸGM⛢/ⒸG·ⓇG))-XPON(UVAL(ⒸGM⛢/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM⛢*ⒸM⛢);-2);1_kg)' "
+                "  'ⓇG' "
+                "  8.682E25_kg ]",
     // *Uranus equatorial radius - Measurement [22]
     "Req⛢",     "[ 25559_km "
                 "  4_km "
@@ -1805,6 +1845,11 @@ static const cstring basic_constants[] =
                 "  0.00000010058E15_m³/s² "
                 "  'ROUND(ⓈGM♆/ⒸGM♆;-2)' "
                 "  6.837E15_m³/s² ]",
+    // *Neptune mass - Calculation from GM and G
+    "M♆",       "[ 'ROUND(CONVERT(ⒸGM♆/ⒸG;1_kg);XPON(UVAL(ⒸGM♆/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♆/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♆*ⒸM♆);-2);1_kg)' "
+                "  'ⓇG' "
+                "  1.024E26_kg ]",
     // *Neptune equatorial radius - Measurement [22]
     "Req♆",     "[ 24764_km "
                 "  15_km "
@@ -1877,6 +1922,11 @@ static const cstring basic_constants[] =
     "GM♇",      "[ 9.755E11_m³/s² "
                 "  0.005E11_m³/s² "
                 "  'ROUND(ⓈGM♇/ⒸGM♇;-2)' ]",
+    // *Pluto mass - Calculation from GM and G
+    "M♇",       "[ 'ROUND(CONVERT(ⒸGM♇/ⒸG;1_kg);XPON(UVAL(ⒸGM♇/ⒸG·ⓇG))-XPON(UVAL(ⒸGM♇/ⒸG))-2)' "
+                "  'CONVERT(ROUND(UBASE(ⓇM♇*ⒸM♇);-2);1_kg)' "
+                "  'ⓇG' "
+                "  1.462E22_kg ]",
     // *Pluto equatorial radius - Measurement [26]
     "Req♇",     "[ 1188.3_km "
                 "  1.6_km "

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1254,7 +1254,7 @@ static const cstring basic_constants[] =
                 "  5.067E6_s ]",
     // *Mercury rotation angular velocity - Calculation from Prot
     "ωrot☿",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☿;1_r/s);XPON(UVAL(Ⓡωrot☿*(2*Ⓒπ*1_r)/ⒸProt☿))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☿))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☿*(2*Ⓒπ*1_r)/ⒸProt☿);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot☿*(2*Ⓒπ*1_r)/ⒸProt☿;-2);1_r/s)' "
                 "  'ⓇProt☿' ]",
     // *Mercury axial tilt - Measurement [22]
     "ϵ☿",       "[ 0.034_° "
@@ -1338,7 +1338,7 @@ static const cstring basic_constants[] =
                 "  2.100E7_s ]",
     // *Venus rotation angular velocity - Calculation from Prot  [retrograde]
     "ωrot♀",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt♀;1_r/s);XPON(UVAL(Ⓡωrot♀*(2*Ⓒπ*1_r)/ⒸProt♀))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♀))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♀*(2*Ⓒπ*1_r)/ⒸProt♀);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♀*(2*Ⓒπ*1_r)/ⒸProt♀;-2);1_r/s)' "
                 "  'ⓇProt♀' ]",
     // *Venus axial tilt - Measurement [22]
     "ϵ♀",       "[ 177.36_° "
@@ -1396,7 +1396,7 @@ static const cstring basic_constants[] =
                 "  0_km "
                 "  0 ]",
     // *Earth oblateness - Calculation from nominal value [3]
-    "f♁",       "[ 'ROUND(1-ⒸRp♁/ⒸReq♁;XPON(UVAL(Ⓡf♁*(1-ⒸRp♁/ⒸReq♁)))-XPON(1-ⒸRp♁/ⒸReq♁)-2)' "
+    "f♁",       "[ 'ROUND(1-ⒸRp♁/ⒸReq♁;-5)' "
                 "  'ROUND(Ⓡf♁*Ⓒf♁;-2)' "
                 "  'ⓇRp♁+ⓇReq♁' ]",
     // *Earth mean density - Calculation from nominal value [3]
@@ -1420,7 +1420,7 @@ static const cstring basic_constants[] =
                 "  8.616E4_s ]",
     // *Earth rotation angular velocity - Calculation from Prot
     "ωrot♁",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♁;1_r/s);XPON(UVAL(Ⓡωrot♁*(2*Ⓒπ*1_r)/ⒸProt♁))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♁))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♁*(2*Ⓒπ*1_r)/ⒸProt♁);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♁*(2*Ⓒπ*1_r)/ⒸProt♁;-2);1_r/s)' "
                 "  'ⓇProt♁' ]",
     // *Earth axial tilt - Measurement [24]
     "ϵ♁",       "[ 23.4393_° "
@@ -1547,7 +1547,7 @@ static const cstring basic_constants[] =
                 "  2.361E6_s ]",
     // *Moon rotation angular velocity - Calculation from Prot
     "ωrot☽",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☽;1_r/s);XPON(UVAL(Ⓡωrot☽*(2*Ⓒπ*1_r)/ⒸProt☽))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☽))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☽*(2*Ⓒπ*1_r)/ⒸProt☽);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot☽*(2*Ⓒπ*1_r)/ⒸProt☽;-2);1_r/s)' "
                 "  'ⓇProt☽' ]",
     // *Moon axial tilt - Measurement [22]
     "ϵ☽",       "[ 1.5424_° "
@@ -1631,7 +1631,7 @@ static const cstring basic_constants[] =
                 "  8.864E4_s ]",
     // *Mars rotation angular velocity - Calculation from Prot
     "ωrot♂",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♂;1_r/s);XPON(UVAL(Ⓡωrot♂*(2*Ⓒπ*1_r)/ⒸProt♂))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♂))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♂*(2*Ⓒπ*1_r)/ⒸProt♂);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♂*(2*Ⓒπ*1_r)/ⒸProt♂;-2);1_r/s)' "
                 "  'ⓇProt♂' ]",
     // *Mars axial tilt - Measurement [22]
     "ϵ♂",       "[ 25.19_° "
@@ -1687,7 +1687,7 @@ static const cstring basic_constants[] =
                 "  0_km "
                 "  0 ]",
     // *Jupiter oblateness - Calculation from nominal value [3]
-    "f♃",       "[ 'ROUND(1-ⒸRp♃/ⒸReq♃;XPON(UVAL(Ⓡf♃*(1-ⒸRp♃/ⒸReq♃)))-XPON(1-ⒸRp♃/ⒸReq♃)-2)' "
+    "f♃",       "[ 'ROUND(1-ⒸRp♃/ⒸReq♃;-5)' "
                 "  'ROUND(Ⓡf♃*Ⓒf♃;-2)' "
                 "  'ⓇRp♃+ⓇReq♃' ]",
     // *Jupiter mean density - Calculation from nominal value [3]
@@ -1710,7 +1710,7 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♃/ⒸProt♃;-2)' ]",
     // *Jupiter rotation angular velocity - Calculation from Prot
     "ωrot♃",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♃;1_r/s);XPON(UVAL(Ⓡωrot♃*(2*Ⓒπ*1_r)/ⒸProt♃))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♃))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♃*(2*Ⓒπ*1_r)/ⒸProt♃);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♃*(2*Ⓒπ*1_r)/ⒸProt♃;-2);1_r/s)' "
                 "  'ⓇProt♃' ]",
     // *Jupiter axial tilt - Measurement [22]
     "ϵ♃",       "[ 3.13_° "
@@ -1793,7 +1793,7 @@ static const cstring basic_constants[] =
                 "  3.836E4_s ]",
     // *Saturn rotation angular velocity - Calculation from Prot
     "ωrot♄",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♄;1_r/s);XPON(UVAL(Ⓡωrot♄*(2*Ⓒπ*1_r)/ⒸProt♄))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♄))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♄*(2*Ⓒπ*1_r)/ⒸProt♄);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♄*(2*Ⓒπ*1_r)/ⒸProt♄;-2);1_r/s)' "
                 "  'ⓇProt♄' ]",
     // *Saturn axial tilt - Measurement [22]
     "ϵ♄",       "[ 26.73_° "
@@ -1876,7 +1876,7 @@ static const cstring basic_constants[] =
                 "  6.206E4_s ]",
     // *Uranus rotation angular velocity - Calculation from Prot  [retrograde]
     "ωrot⛢",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt⛢;1_r/s);XPON(UVAL(Ⓡωrot⛢*(2*Ⓒπ*1_r)/ⒸProt⛢))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt⛢))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot⛢*(2*Ⓒπ*1_r)/ⒸProt⛢);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot⛢*(2*Ⓒπ*1_r)/ⒸProt⛢;-2);1_r/s)' "
                 "  'ⓇProt⛢' ]",
     // *Uranus axial tilt - Measurement [22]
     "ϵ⛢",       "[ 97.77_° "
@@ -1958,7 +1958,7 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♆/ⒸProt♆;-2)' ]",
     // *Neptune rotation angular velocity - Calculation from Prot
     "ωrot♆",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♆;1_r/s);XPON(UVAL(Ⓡωrot♆*(2*Ⓒπ*1_r)/ⒸProt♆))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♆))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♆*(2*Ⓒπ*1_r)/ⒸProt♆);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♆*(2*Ⓒπ*1_r)/ⒸProt♆;-2);1_r/s)' "
                 "  'ⓇProt♆' ]",
     // *Neptune axial tilt - Measurement [22]
     "ϵ♆",       "[ 28.32_° "
@@ -2040,7 +2040,7 @@ static const cstring basic_constants[] =
                 "  5.519E5_s ]",
     // *Pluto rotation angular velocity - Calculation from Prot  [retrograde]
     "ωrot♇",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt♇;1_r/s);XPON(UVAL(Ⓡωrot♇*(2*Ⓒπ*1_r)/ⒸProt♇))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♇))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♇*(2*Ⓒπ*1_r)/ⒸProt♇);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot♇*(2*Ⓒπ*1_r)/ⒸProt♇;-2);1_r/s)' "
                 "  'ⓇProt♇' ]",
     // *Pluto axial tilt - Measurement [26]
     "ϵ♇",       "[ 119.591_° "
@@ -2126,7 +2126,7 @@ static const cstring basic_constants[] =
                 "  2.193E6_s ]",
     // *Sun rotation angular velocity - Calculation from Prot
     "ωrot☉",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☉;1_r/s);XPON(UVAL(Ⓡωrot☉*(2*Ⓒπ*1_r)/ⒸProt☉))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☉))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☉*(2*Ⓒπ*1_r)/ⒸProt☉);-2);1_r/s)' "
+                "  'CONVERT(ROUND(Ⓡωrot☉*(2*Ⓒπ*1_r)/ⒸProt☉;-2);1_r/s)' "
                 "  'ⓇProt☉' ]",
 
     "Astronomy/Cosmology",     nullptr,

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1253,8 +1253,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt☿/ⒸProt☿;-2)' "
                 "  5.067E6_s ]",
     // *Mercury rotation angular velocity - Calculation from Prot
-    "ωrot☿",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☿;1_r/s);XPON(UVAL(Ⓡωrot☿*2*Ⓒπ/ⒸProt☿))-XPON(UVAL(2*Ⓒπ/ⒸProt☿))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☿*2*Ⓒπ/ⒸProt☿);-2);1_r/s)' "
+    "ωrot☿",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☿;1_r/s);XPON(UVAL(Ⓡωrot☿*(2*Ⓒπ*1_r)/ⒸProt☿))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☿))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☿*(2*Ⓒπ*1_r)/ⒸProt☿);-2);1_r/s)' "
                 "  'ⓇProt☿' ]",
     // *Mercury axial tilt - Measurement [22]
     "ϵ☿",       "[ 0.034_° "
@@ -1337,8 +1337,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♀/ⒸProt♀;-2)' "
                 "  2.100E7_s ]",
     // *Venus rotation angular velocity - Calculation from Prot  [retrograde]
-    "ωrot♀",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt♀;1_r/s);XPON(UVAL(Ⓡωrot♀*2*Ⓒπ/ⒸProt♀))-XPON(UVAL(2*Ⓒπ/ⒸProt♀))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♀*2*Ⓒπ/ⒸProt♀);-2);1_r/s)' "
+    "ωrot♀",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt♀;1_r/s);XPON(UVAL(Ⓡωrot♀*(2*Ⓒπ*1_r)/ⒸProt♀))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♀))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♀*(2*Ⓒπ*1_r)/ⒸProt♀);-2);1_r/s)' "
                 "  'ⓇProt♀' ]",
     // *Venus axial tilt - Measurement [22]
     "ϵ♀",       "[ 177.36_° "
@@ -1419,8 +1419,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♁/ⒸProt♁;-2)' "
                 "  8.616E4_s ]",
     // *Earth rotation angular velocity - Calculation from Prot
-    "ωrot♁",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♁;1_r/s);XPON(UVAL(Ⓡωrot♁*2*Ⓒπ/ⒸProt♁))-XPON(UVAL(2*Ⓒπ/ⒸProt♁))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♁*2*Ⓒπ/ⒸProt♁);-2);1_r/s)' "
+    "ωrot♁",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♁;1_r/s);XPON(UVAL(Ⓡωrot♁*(2*Ⓒπ*1_r)/ⒸProt♁))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♁))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♁*(2*Ⓒπ*1_r)/ⒸProt♁);-2);1_r/s)' "
                 "  'ⓇProt♁' ]",
     // *Earth axial tilt - Measurement [24]
     "ϵ♁",       "[ 23.4393_° "
@@ -1477,11 +1477,11 @@ static const cstring basic_constants[] =
                 "  0_m³/s² "
                 "  0 ]",
     // *Earth first eccentricity squared - WGS-84 ellipsoid, from flattening [WGS-84]
-    "e²♁GPS",   "[ '2*Ⓒf♁GPS-Ⓒf♁GPS²' "
+    "e12♁GPS",  "[ '2*Ⓒf♁GPS-Ⓒf♁GPS²' "
                 "  0 "
                 "  0 ]",
     // *Earth second eccentricity squared - WGS-84 ellipsoid, from first [WGS-84]
-    "e'²♁GPS",  "[ 'Ⓒe²♁GPS/(1-Ⓒe²♁GPS)' "
+    "e22♁GPS",  "[ 'Ⓒe12♁GPS/(1-Ⓒe12♁GPS)' "
                 "  0 "
                 "  0 ]",
 
@@ -1546,8 +1546,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt☽/ⒸProt☽;-2)' "
                 "  2.361E6_s ]",
     // *Moon rotation angular velocity - Calculation from Prot
-    "ωrot☽",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☽;1_r/s);XPON(UVAL(Ⓡωrot☽*2*Ⓒπ/ⒸProt☽))-XPON(UVAL(2*Ⓒπ/ⒸProt☽))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☽*2*Ⓒπ/ⒸProt☽);-2);1_r/s)' "
+    "ωrot☽",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☽;1_r/s);XPON(UVAL(Ⓡωrot☽*(2*Ⓒπ*1_r)/ⒸProt☽))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☽))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☽*(2*Ⓒπ*1_r)/ⒸProt☽);-2);1_r/s)' "
                 "  'ⓇProt☽' ]",
     // *Moon axial tilt - Measurement [22]
     "ϵ☽",       "[ 1.5424_° "
@@ -1630,8 +1630,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♂/ⒸProt♂;-2)' "
                 "  8.864E4_s ]",
     // *Mars rotation angular velocity - Calculation from Prot
-    "ωrot♂",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♂;1_r/s);XPON(UVAL(Ⓡωrot♂*2*Ⓒπ/ⒸProt♂))-XPON(UVAL(2*Ⓒπ/ⒸProt♂))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♂*2*Ⓒπ/ⒸProt♂);-2);1_r/s)' "
+    "ωrot♂",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♂;1_r/s);XPON(UVAL(Ⓡωrot♂*(2*Ⓒπ*1_r)/ⒸProt♂))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♂))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♂*(2*Ⓒπ*1_r)/ⒸProt♂);-2);1_r/s)' "
                 "  'ⓇProt♂' ]",
     // *Mars axial tilt - Measurement [22]
     "ϵ♂",       "[ 25.19_° "
@@ -1709,8 +1709,8 @@ static const cstring basic_constants[] =
                 "  1_s "
                 "  'ROUND(ⓈProt♃/ⒸProt♃;-2)' ]",
     // *Jupiter rotation angular velocity - Calculation from Prot
-    "ωrot♃",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♃;1_r/s);XPON(UVAL(Ⓡωrot♃*2*Ⓒπ/ⒸProt♃))-XPON(UVAL(2*Ⓒπ/ⒸProt♃))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♃*2*Ⓒπ/ⒸProt♃);-2);1_r/s)' "
+    "ωrot♃",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♃;1_r/s);XPON(UVAL(Ⓡωrot♃*(2*Ⓒπ*1_r)/ⒸProt♃))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♃))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♃*(2*Ⓒπ*1_r)/ⒸProt♃);-2);1_r/s)' "
                 "  'ⓇProt♃' ]",
     // *Jupiter axial tilt - Measurement [22]
     "ϵ♃",       "[ 3.13_° "
@@ -1792,8 +1792,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♄/ⒸProt♄;-2)' "
                 "  3.836E4_s ]",
     // *Saturn rotation angular velocity - Calculation from Prot
-    "ωrot♄",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♄;1_r/s);XPON(UVAL(Ⓡωrot♄*2*Ⓒπ/ⒸProt♄))-XPON(UVAL(2*Ⓒπ/ⒸProt♄))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♄*2*Ⓒπ/ⒸProt♄);-2);1_r/s)' "
+    "ωrot♄",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♄;1_r/s);XPON(UVAL(Ⓡωrot♄*(2*Ⓒπ*1_r)/ⒸProt♄))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♄))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♄*(2*Ⓒπ*1_r)/ⒸProt♄);-2);1_r/s)' "
                 "  'ⓇProt♄' ]",
     // *Saturn axial tilt - Measurement [22]
     "ϵ♄",       "[ 26.73_° "
@@ -1875,8 +1875,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt⛢/ⒸProt⛢;-2)' "
                 "  6.206E4_s ]",
     // *Uranus rotation angular velocity - Calculation from Prot  [retrograde]
-    "ωrot⛢",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt⛢;1_r/s);XPON(UVAL(Ⓡωrot⛢*2*Ⓒπ/ⒸProt⛢))-XPON(UVAL(2*Ⓒπ/ⒸProt⛢))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot⛢*2*Ⓒπ/ⒸProt⛢);-2);1_r/s)' "
+    "ωrot⛢",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt⛢;1_r/s);XPON(UVAL(Ⓡωrot⛢*(2*Ⓒπ*1_r)/ⒸProt⛢))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt⛢))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot⛢*(2*Ⓒπ*1_r)/ⒸProt⛢);-2);1_r/s)' "
                 "  'ⓇProt⛢' ]",
     // *Uranus axial tilt - Measurement [22]
     "ϵ⛢",       "[ 97.77_° "
@@ -1957,8 +1957,8 @@ static const cstring basic_constants[] =
                 "  100_s "
                 "  'ROUND(ⓈProt♆/ⒸProt♆;-2)' ]",
     // *Neptune rotation angular velocity - Calculation from Prot
-    "ωrot♆",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt♆;1_r/s);XPON(UVAL(Ⓡωrot♆*2*Ⓒπ/ⒸProt♆))-XPON(UVAL(2*Ⓒπ/ⒸProt♆))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♆*2*Ⓒπ/ⒸProt♆);-2);1_r/s)' "
+    "ωrot♆",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt♆;1_r/s);XPON(UVAL(Ⓡωrot♆*(2*Ⓒπ*1_r)/ⒸProt♆))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♆))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♆*(2*Ⓒπ*1_r)/ⒸProt♆);-2);1_r/s)' "
                 "  'ⓇProt♆' ]",
     // *Neptune axial tilt - Measurement [22]
     "ϵ♆",       "[ 28.32_° "
@@ -2039,8 +2039,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt♇/ⒸProt♇;-2)' "
                 "  5.519E5_s ]",
     // *Pluto rotation angular velocity - Calculation from Prot  [retrograde]
-    "ωrot♇",    "[ 'ROUND(CONVERT(-2*Ⓒπ/ⒸProt♇;1_r/s);XPON(UVAL(Ⓡωrot♇*2*Ⓒπ/ⒸProt♇))-XPON(UVAL(2*Ⓒπ/ⒸProt♇))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot♇*2*Ⓒπ/ⒸProt♇);-2);1_r/s)' "
+    "ωrot♇",    "[ 'ROUND(CONVERT(-(2*Ⓒπ*1_r)/ⒸProt♇;1_r/s);XPON(UVAL(Ⓡωrot♇*(2*Ⓒπ*1_r)/ⒸProt♇))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt♇))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot♇*(2*Ⓒπ*1_r)/ⒸProt♇);-2);1_r/s)' "
                 "  'ⓇProt♇' ]",
     // *Pluto axial tilt - Measurement [26]
     "ϵ♇",       "[ 119.591_° "
@@ -2125,8 +2125,8 @@ static const cstring basic_constants[] =
                 "  'ROUND(ⓈProt☉/ⒸProt☉;-2)' "
                 "  2.193E6_s ]",
     // *Sun rotation angular velocity - Calculation from Prot
-    "ωrot☉",    "[ 'ROUND(CONVERT(2*Ⓒπ/ⒸProt☉;1_r/s);XPON(UVAL(Ⓡωrot☉*2*Ⓒπ/ⒸProt☉))-XPON(UVAL(2*Ⓒπ/ⒸProt☉))-2)' "
-                "  'CONVERT(ROUND(UBASE(Ⓡωrot☉*2*Ⓒπ/ⒸProt☉);-2);1_r/s)' "
+    "ωrot☉",    "[ 'ROUND(CONVERT((2*Ⓒπ*1_r)/ⒸProt☉;1_r/s);XPON(UVAL(Ⓡωrot☉*(2*Ⓒπ*1_r)/ⒸProt☉))-XPON(UVAL((2*Ⓒπ*1_r)/ⒸProt☉))-2)' "
+                "  'CONVERT(ROUND(UBASE(Ⓡωrot☉*(2*Ⓒπ*1_r)/ⒸProt☉);-2);1_r/s)' "
                 "  'ⓇProt☉' ]",
 
     "Astronomy/Cosmology",     nullptr,

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -1458,6 +1458,48 @@ static const cstring basic_constants[] =
                 "  0_date "
                 "  0 ]",
 
+    // ------------------------------------------------------------------------
+    // WGS-84 / GPS reference ellipsoid (defining constants, exact)
+    // *Earth equatorial radius - WGS-84 defining constant [WGS-84]
+    "a♁GPS",    "[ 6378137_m "
+                "  0_m "
+                "  0 ]",
+    // *Earth flattening - WGS-84 defining constant 1/298.257223563 [WGS-84]
+    "f♁GPS",    "[ '1/298.257223563' "
+                "  0 "
+                "  0 ]",
+    // *Earth nominal mean angular velocity - WGS-84 [WGS-84]
+    "ω♁GPS",    "[ 7.2921150E-5_r/s "
+                "  0_r/s "
+                "  0 ]",
+    // *Earth gravitational parameter (incl. atmosphere) - WGS-84 [WGS-84]
+    "GM♁GPS",   "[ 3.986004418E14_m³/s² "
+                "  0_m³/s² "
+                "  0 ]",
+    // *Earth first eccentricity squared - WGS-84 ellipsoid, from flattening [WGS-84]
+    "e²♁GPS",   "[ '2*Ⓒf♁GPS-Ⓒf♁GPS²' "
+                "  0 "
+                "  0 ]",
+    // *Earth second eccentricity squared - WGS-84 ellipsoid, from first [WGS-84]
+    "e'²♁GPS",  "[ 'Ⓒe²♁GPS/(1-Ⓒe²♁GPS)' "
+                "  0 "
+                "  0 ]",
+
+    // ------------------------------------------------------------------------
+    // Calendar and astronomical years
+    // *Tropical year (equinox to equinox, J2000) - seasonal year [24]
+    "Ytrop♁",   "[ 365.24219_d "
+                "  0_d "
+                "  0 ]",
+    // *Julian year - exact, defines the light-year [24]
+    "YJul♁",    "[ 365.25_d "
+                "  0_d "
+                "  0 ]",
+    // *Gregorian mean year - exact: 365 + 1/4 - 1/100 + 1/400 [24]
+    "YGreg♁",   "[ 365.2425_d "
+                "  0_d "
+                "  0 ]",
+
     "Astronomy/Moon",     nullptr,
 
     // *Moon gravitational parameter - Measurement [4]


### PR DESCRIPTION
constants: Completeness — masses, ωrot, WGS-84/GPS, calendar years

  C1. Add computed masses M_id = GM_id/G for the 9 planets + Moon (after each
      GM_id; copy of the M☉ pattern; relative uncertainty = ⓇG). Sun already has
      M☉. Same commit: matching constants.md.
  C2. Add ωrot_id = 2π/Prot_id for the 9 planets + Moon + Sun (after each Prot_id;
      unit r/s). ♀ ⛢ ♇ are retrograde → minus sign on the VALUE only (the
      uncertainty uses the positive magnitude). Same commit: matching constants.md.
  C3. At the end of Astronomy/Earth: the WGS-84/GPS reference block (a♁GPS, f♁GPS,
      ω♁GPS, GM♁GPS, e12♁GPS, e22♁GPS — DEFINED/exact, uncertainty 0; the two
      eccentricities are computed from f♁GPS) and the three years (Ytrop♁, YJul♁,
      YGreg♁). INSERTION POINT: immediately after the last existing constant of
      the Astronomy/Earth section (after e♁, the orbital eccentricity), before
      the next section header (Astronomy/Moon). Same commit: constants.md text
      distinguishing them from Porb♁ (years) and from the ORBITAL eccentricity e♁
      (the GPS ei2 are ellipsoid eccentricities, a different quantity) — see the
      year note below.

constants.md YEAR note (for C3): Porb♁ = anomalistic year (perihelion-to-
perihelion, 365.2657 d; the one T0 uses). Ytrop♁ = tropical/seasonal year
(365.24219 d). YJul♁ = Julian year (365.25 d, exact; defines the light-year).
YGreg♁ = Gregorian mean year (365.2425 d, exact). The sidereal year (365.25636 d)
exists but is not stored.