### PR TITLE
Doc: documentation and example for constants menu hierarchy.

### DIFF
--- a/config/constants.csv
+++ b/config/constants.csv
@@ -1,5 +1,14 @@
 "Dates"
 
-"BastilleDay",              "17890714_date"
-"MartinLutherKingDeath",    "19680404_date"
-"IndependenceDay",          "17760704_date"
+"Dates/America"
+"IndigenousPeoplesDay",		"14921012_date"
+
+"Dates/Australia"
+"AustraliaDay",			"17880126_date"
+
+"Dates/France"
+"BastilleDay",			"17890714_date"
+
+"Dates/USA"
+"IndependenceDay",      	"17760704_date"
+"MartinLutherKingDeath",	"19680404_date" 

--- a/doc/config/constants.md
+++ b/doc/config/constants.md
@@ -1,0 +1,42 @@
+## config/constants.csv
+
+With this file you can add your own constants, or overrule build in constants.
+
+The first column is interpreted as either:
+- a menu label (when there is no second column);
+- a constant name.
+
+The second column is interpreted as the constant value.
+
+
+A hierarchy of menus is created by using a forward slash as separator between the levels in the menu label.
+```
+"Dates"
+
+"Dates/America"
+"IndigenousPeoplesDay",		"14921012_date"
+```
+Only the deepest menu level may contain constants.
+Constants on intermediate levels are ignored.
+
+
+The constant value can be a single value, as above, or an array containing:
+- value;
+- standard uncertainty;
+- relative uncertainty;
+- optionally a label (defaults to the value).
+
+```
+"Sample"
+
+"C1",	"[ 3 0.5 0.16667 aLabel ]"
+"C2",	"[ '1+2' 0.5 1/6 ]"
+"C3",	"[ v sv 'sv / v' ]"
+```
+As shown, algebraic expressions can be used.
+Even variables can be used.
+For `C3` the variables `v` and `sv` have to defined.
+
+Using other constants, their absolute or relative uncertainty in the value (array) of a constant, may not work.
+It may crash the calculator program.
+An rpl program can be put int the value (array) but it will not be evaluated.


### PR DESCRIPTION
Version 0.9.19 introduces submenus for the constant menus. I Changed and extended the example in config/constants.csv to use this feature.

The config files are mentioned and referred to in the rest of the documentation but not separately documented.
This new feature was left undocumented.

I documented the config/constants.csv file including the new feature.

It is not immediately obvious where to put the added documentation. All the documentation could do with a restructuring. The other config files could do with documentation also.

For now I chose: doc/config/constants.md

Signed-off-by: Ed@vanGasteren.net