### PR TITLE
Makefile: package the library subdirectories, not just library/*.48s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -724,7 +724,7 @@ TAR_EXTRA_FILES=	   				\
 	    help/*.bmp help/*/*.bmp			\
 	    state/*.48[sSbB]				\
 	    config/*.csv config/*.48k config/*.cfg	\
-	    library/*.48[sSbB]
+	    library/*.48[sSbB] library/*/*.48[sSbB]
 
 PRINT_INSTALL=$(PRINT_COMMAND) $(INFO) "[INSTALL]" "$(NAME) => $(MOUNTPOINT)/" $(COLOR_FILTER);
 PRINT_PACKAGE=$(PRINT_COMMAND) $(INFO) "[PACKAGE]" "$(NAME)-$(VERSION)" $(COLOR_FILTER);


### PR DESCRIPTION
`TAR_EXTRA_FILES` globs the RPL library as `library/*.48[sSbB]`, which is flat. Since the library was reorganised into subdirectories (`Astronomy`, `Astronautics`, `Missions`, `AstroExamples`), 71 of the 93 programs no longer match, so `make dist` and `make install` ship 22 programs — while still shipping `config/library.csv`, which names the missing ones by path. On the device the library is read from the calculator disk, so those entries point at files that are not there, and each one fails with `Invalid or unknown library entry`.

The defect is invisible on the simulator: the Qt build embeds the whole library as resources, and a simulator binary copied alone into an empty directory still resolves entries whose files were never packaged. It only surfaces when packaging for hardware.

The fix adds one more level of glob to `TAR_EXTRA_FILES`:

```make
    library/*.48[sSbB] library/*/*.48[sSbB]
```

where the second pattern is the new one. Verified on the `dm32` target: the tarball goes from 22 to 93 `.48s` files.

This is the hardware half of #1722, and it has to land with or before the library it packages: merging #1718 without it gives the calculator a `config/library.csv` naming 71 files that were never shipped, which is that issue exactly.

Rebuilt on `stable`, one commit.