### PR TITLE
Android: ship the library and configuration, not just the help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,8 +546,8 @@ sim/%.qrc: $(MIQ_MAKEDEPS)
 	$(PRINT_GENERATE) (echo '<RCC>';			\
 	 echo ' <qresource prefix="/'$*'">';			\
 	 for I in $(wildcard $(QRC_EXT_$*:%=$*/%)); do		\
-		J=$$(basename $$I);				\
-		echo '  <file alias="'$$J'">../'$(QRC_DOT_$*)$*'/'$$J'</file>';	\
+		J=$${I#$*/};					\
+		echo '  <file alias="'$$J'">../'$(QRC_DOT_$*)$$I'</file>';	\
 	 done;							\
 	 echo ' </qresource>';					\
 	 echo '</RCC>')						\
@@ -558,7 +558,7 @@ QRC_EXT_config=*.csv *.cfg *.48k
 QRC_EXT_help=$(NAME).md $(NAME).idx
 QRC_EXT_help/img=*.bmp
 QRC_DOT_help/img=../
-QRC_EXT_library=*.48[sS]
+QRC_EXT_library=*.48[sS] */*.48[sS]
 QRC_EXT_state=*.48[sS]
 
 keyboard:				\

--- a/sim/sim-window.cpp
+++ b/sim/sim-window.cpp
@@ -67,6 +67,7 @@
 #include <QtMath>
 #ifdef ANDROID
 #include <QDir>
+#include <QDirIterator>
 #include <QSettings>
 #include <atomic>
 
@@ -427,28 +428,37 @@ void extract_android_assets()
     QString savedAssetVersion = settings.value("AssetVersion", "").toString();
 
     if (savedAssetVersion != currentAssetVersion) {
-        QStringList filesToExtract = {"db48x.idx", "db48x.md"};
-
-        for (const QString& fileName : filesToExtract) {
-            QString assetPath = ":/help/" + fileName; // Check your Qt resource prefix
-            QString targetPath = sandboxDir + "/help/" + fileName;
-
-            if (QFile::exists(targetPath)) {
-                QFile::remove(targetPath);
+        // The RPL engine opens its files with fopen(), so Qt resources are
+        // invisible to it: they must exist as real files. Extract the whole
+        // resource tree, not just the help. Without config/library.csv and
+        // library/*.48s on disk, the only reachable library entries are the
+        // ones compiled into basic_library[], i.e. Secrets and Physics.
+        QDir from(":/");
+        QDir to(sandboxDir);
+        QDirIterator it(":/", QDirIterator::Subdirectories);
+        while (it.hasNext())
+        {
+            QFileInfo fi(it.next());
+            QString relPath = from.relativeFilePath(fi.absoluteFilePath());
+            QString absPath = to.filePath(relPath);
+            if (fi.isDir())
+            {
+                QDir().mkpath(absPath);
             }
-
-	    // Create the directory structure if it doesn't exist
-	    QFileInfo targetInfo(targetPath);
-	    QDir().mkpath(targetInfo.absolutePath());
-
-            QFile assetFile(assetPath);
-            if (assetFile.copy(targetPath)) {
-                QFile::setPermissions(targetPath,
-                    QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ReadUser);
+            else if (fi.isFile())
+            {
+                QFileInfo targetInfo(absPath);
+                QDir().mkpath(targetInfo.absolutePath());
+                QFile::remove(absPath);
+                if (QFile::copy(fi.absoluteFilePath(), absPath))
+                    QFile::setPermissions(absPath,
+                                          QFileDevice::ReadOwner  |
+                                          QFileDevice::WriteOwner |
+                                          QFileDevice::ReadUser);
             }
         }
 
-	settings.setValue("AssetVersion", currentAssetVersion);
+        settings.setValue("AssetVersion", currentAssetVersion);
     }
 
     QDir::setCurrent(sandboxDir);


### PR DESCRIPTION
Follows @c3d's note in #1656: *"I would probably just blindly take a PR that implements your suggestion @evgaster. As long as you minimally tested it."* This is that PR, and it has been tested on two devices rather than one.

Two files, +31/−21, cherry-picked cleanly onto current `dev`.

## The problem

On Android the app started and ran, but its Function Library held only **Secrets** and **Physics** — exactly the two sections compiled into `basic_library[]` in `src/library.cc`. Everything read from disk was missing, on a device as on the emulator.

## Two independent causes

**1. Assets were not extracted.** `extract_android_assets()` in `sim/sim-window.cpp` extracted exactly two files:

```cpp
QStringList filesToExtract = {"db48x.idx", "db48x.md"};
```

The RPL engine opens files with `fopen()` (`src/file.cc`), to which Qt resources are invisible, so `config/library.csv` and `library/*.48s` must exist as real files under the app data directory. The desktop path already does the right thing — `copy(":/", files)` in `sim-main.cpp` — but it is guarded by `!QDir(files).exists()`, false on Android where the system creates the data directory at install time.

The fix extracts the whole resource tree, reusing that same logic, and keeps the existing `AssetVersion` guard so extraction still runs only when the version changes.

**2. The resource glob was flat.** `QRC_EXT_library` (Makefile line 561) was `*.48[sS]`, so since the library was reorganised into sub-directories only 22 of the 93 programs were embedded.

The alias had to change too: in a `.qrc` it is the **alias**, not the source path, that fixes a file's place in the resource tree and therefore where it is extracted. `basename()` put `Astronomy/MerPhif.48s` at `/library/MerPhif.48s`, while `library.csv` asks for `/library/Astronomy/MerPhif.48s`. Using the path relative to the prefix leaves the flat entries and the other `.qrc` files unchanged.

This is the same flat-glob mistake as the packaging one in #1723, in a third place. It is invisible on desktop, where the missing programs are read from `~/.local/share/DB48X/DB48X` instead.

## Testing

| | |
|---|---|
| Samsung Galaxy S20 FE, arm64 | full 93-program library; `ETMB1` runs and returns its complete tagged output, so the `OppRoute → ♀Pf/♁Pf/♂Pf → LambertU` chain resolves on the phone |
| Google Pixel 10 (@evgaster, #1656) | side-loaded the same build: survives screen lock and app switch, help works, library present, `ETMB1` runs |

Built and verified with `dm42-android`. `color-dm32-android` uses the same toolchain but I have not tried it.

## One point for review

Embedding 93 programs instead of 22 also changes what the desktop `-I` option installs. That looks desirable — the user environment becomes complete — but it is a behaviour change worth knowing about.

## Not in this PR

Three related items, each separable:

- moving the extraction target to `getExternalFilesDir()` so a file manager can reach it — closer to a product decision, discussed in #1656
- deriving `versionCode` / `versionName` from `git describe` instead of the hardcoded `0.9.14` / `2` in `sim/android/AndroidManifest.xml`, which currently blocks any Play Store update
- the packaging fix for library sub-directories in #1723

Related: #1656, #1723.