### PR TITLE
gitattributes: do not normalise the images that live under doc/ and help/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep markdown sources LF on all platforms (Windows CI builds help from these)
+doc/** text eol=lf
+help/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Keep markdown sources LF on all platforms (Windows CI builds help from these)
 doc/** text eol=lf
 help/** text eol=lf
+
+# The two rules above also match the images that live beside the markdown.
+# Binary assets must never be line-ending normalised.
+*.bmp binary
+*.png binary

--- a/src/file.cc
+++ b/src/file.cc
@@ -147,7 +147,7 @@ void file::open(cstring path, mode wrmode)
     name = path;
 
 #if SIMULATOR
-    data = fopen(path, reading ? "r" : append ? "a" : "w");
+    data = fopen(path, reading ? "rb" : append ? "ab" : "wb");
     if (!data)
     {
         record(file_error, "Error %s opening %s", strerror(errno), path);


### PR DESCRIPTION
Five lines added to `.gitattributes`, nothing else touched.

## What happens

`dce05c4e` marks `doc/**` and `help/**` as `text eol=lf` so the markdown sources keep LF on Windows. Those two patterns also match every image that lives beside them — **108 `.bmp` and 14 `.png` files**.

Line-ending normalisation then strips `CR` bytes from inside binary data. On a fresh checkout of current `dev`, eleven equation-library figures come out one or two bytes short:

```
doc/img/Cyclotron_BW.png               | Bin 12008 -> 12007 bytes
doc/img/Cyclotron_Color.png            | Bin 48548 -> 48547 bytes
doc/img/Fiber Optic BW.png             | Bin 10239 -> 10238 bytes
doc/img/Hall Effect VH Color.png       | Bin 35897 -> 35896 bytes
doc/img/Hall Effect VH.png             | Bin 10674 -> 10672 bytes
doc/img/Helicoidal Motion BW.png       | Bin  9292 ->  9291 bytes
doc/img/Helicoidal Motion Color.png    | Bin 50682 -> 50681 bytes
doc/img/Malus Law BW.png               | Bin 25124 -> 25122 bytes
doc/img/Projectile.png                 | Bin  6692 ->  6691 bytes
...
```

The stored blobs are intact — it is the checkout that mangles them. Which means **the working tree cannot be made clean**: `git checkout -- doc/img/` restores the files and git re-mangles them in the same breath. Only eleven are affected today, because only those happen to contain a `CR LF` byte sequence; any of the other 111 becomes a candidate the moment its content changes.

## The fix

```
*.bmp binary
*.png binary
```

Later rules win, so the markdown rules above are untouched and the Windows help build keeps the LF endings it needs.

Measured on this branch: **twelve modified files before, none after.**

## Possibly related to the Windows CI

I cannot verify this without your test setup, so I am flagging it rather than claiming it. The failing Windows tests and this commit arrived together, and the rule corrupts help images at checkout time on the very platform where `text eol=lf` actually does something. If any test compares rendered screenshots against `help/img/*.bmp`, that would be worth ruling in or out before looking further afield.