### PR TITLE
ci: publish the Android APK alongside the AAB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,6 +497,7 @@ jobs:
         path: |
           android/*.aab
           android/**/*.aab
+          android/build/outputs/apk/**/*.apk
           help/
 
   build-color-android:
@@ -568,6 +569,7 @@ jobs:
         path: |
           android/*.aab
           android/**/*.aab
+          android/build/outputs/apk/**/*.apk
           help/
 
   build-dm42-firmware:


### PR DESCRIPTION
Answers @evgaster's request in #1656. Two lines, one per Android job.

## The APK already exists

`make android` leaves it at

```
android/build/outputs/apk/debug/android-debug.apk
```

but the upload step collects only `*.aab`, so it never leaves the runner. @c3d guessed as much in #1656 — *"IIRC, it's built as an intermediate step, it's just not produced"* — and that is exactly right. Nothing about the build changes; only what is kept.

## Why it matters

Until the app can go to the Play Store, side-loading is the only way onto a device. An APK installs in one tap. An AAB needs `bundletool`, a keystore, `adb`, and a phone in developer mode — the procedure @evgaster worked out in #1656, which took him several attempts and which is well beyond most users.

@evgaster put it plainly: *"If we make it easier for Android users to get the App on their devices (for now side loading an .apk) we might get more feedback."*

## About the signature

The file is debug-signed. That is what makes it directly installable, and it means successive builds update in place rather than being refused for a signature mismatch — so a tester who installs one artifact can install the next one over it and keep their state.

## Base branch

Opened against `stable` rather than `dev`, per @c3d's request to avoid basing work on `dev` while the Windows CI is being repaired. It is a two-line change to one file and applies anywhere.

## Optionally

A `test -f` on the APK path, mirroring the existing *Verify generated AAB* step, would turn a silently missing APK into a loud failure. Left out to keep the diff minimal — say the word and I will add it.

Related: #1656.