### PR TITLE
Makefile: two fixes to the .qrc generation rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,9 +545,10 @@ sim/%.qrc: $(MIQ_MAKEDEPS)
 	@mkdir -p $(@D)
 	$(PRINT_GENERATE) (echo '<RCC>';			\
 	 echo ' <qresource prefix="/'$*'">';			\
-	 for I in $(wildcard $(QRC_EXT_$*:%=$*/%)); do		\
-		J=$$(basename $$I);				\
-		echo '  <file alias="'$$J'">../'$(QRC_DOT_$*)$*'/'$$J'</file>';	\
+	 for I in $(patsubst %,'%',$(wildcard $(QRC_EXT_$*:%=$*/%))); do	\
+		J=$$(basename "$$I");				\
+		E=$$(printf '%s' "$$J" | sed -e 's/&/\&amp;/g');	\
+		echo '  <file alias="'"$$E"'">../'$(QRC_DOT_$*)$*'/'"$$E"'</file>';	\
 	 done;							\
 	 echo ' </qresource>';					\
 	 echo '</RCC>')						\

--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,14 @@ QRC_DOT_help/img=../
 QRC_EXT_library=*.48[sS]
 QRC_EXT_state=*.48[sS]
 
+# The pattern rule above lists a directory, but make cannot know that from
+# the rule alone: without these, adding a file leaves the .qrc untouched and
+# the new resource silently absent from the binary.
+sim/config.qrc:   $(wildcard $(QRC_EXT_config:%=config/%))
+sim/state.qrc:    $(wildcard $(QRC_EXT_state:%=state/%))
+sim/library.qrc:  $(wildcard $(QRC_EXT_library:%=library/%))
+sim/help/img.qrc: $(wildcard $(QRC_EXT_help/img:%=help/img/%))
+
 keyboard:				\
 	Keyboard-Layout.png 		\
 	Keyboard-Cutout.png		\


### PR DESCRIPTION
Two independent defects in `sim/%.qrc`, one commit each. Both were met in practice rather than found by reading.

## 1. An ampersand in a file name stops the build

The recipe expands the file list into a shell `for` loop without quoting, so a name containing `&` is read as the background operator:

```
/bin/bash: -c: line 4: syntax error near unexpected token `&'
```

Quoting is necessary but not sufficient — a bare `&` is not valid XML either, so the failure would merely move from bash to `rcc`. The name is therefore also escaped on the way out.

**Verified** by placing `Test&Amp.bmp` in `help/img`. Before, the build stopped with the error above. After, the resource file is generated and parses as well-formed XML:

```xml
<file alias="Test&amp;Amp.bmp">../../help/img/Test&amp;Amp.bmp</file>
```

**Still unsupported: a space in a name.** `$(wildcard)` returns a space-separated list, so such a name is already several words by the time make hands it over, and no quoting in the recipe can recover it. `help/img/Driven Damped Oscillations.bmp` is silently truncated to `Driven` today and remains so. Worth knowing rather than fixing here.

## 2. Adding a file does not regenerate the resource

`sim/%.qrc` depends on `$(MIQ_MAKEDEPS)` and nothing else, so make has no way to know the recipe reads a directory. Add a program to `library/`, build, and the `.qrc` is left untouched — the program is simply absent from the binary, with no error anywhere.

I hit this adding programs to `library/` and had to delete `sim/library.qrc` by hand before they appeared.

Four prerequisite-only lines, one per target the pattern rule serves, expressed through the existing `QRC_EXT_*` variables so that changing an extension list keeps them in step. `sim/help-$(NAME).qrc` already declares its two inputs and needs nothing.

**Verified**: with the lines in place, creating `library/ZzTest.48s` and running `make sim/library.qrc` reports

```
Prerequisite 'library/ZzTest.48s' is newer than target 'sim/library.qrc'
```

and the entry count goes 21 → 22; removing the file brings it back to 21. Without them, make reports the target up to date and the count does not move.

One limit inherent to timestamps rather than to this change: a file created within the same filesystem tick as the `.qrc` compares equal, not newer, and will not trigger a rebuild.

## Why these two together

They explain each other. A `.qrc` that is never regenerated keeps a stale file list, which is why an ampersand introduced at some point can appear to break the build long after the offending name is gone — and why it can seem to work on one machine and not another. `help/img` in particular is populated by the build and only partly tracked, so a stale copy of a renamed file survives locally while a fresh checkout is clean.

## Base branch

Opened against `stable` rather than `dev`, per @c3d's request while the Windows CI is being repaired.

Related: #1716, where a figure named `CombustionChamber&Nozzle.bmp` is renamed — that is the immediate remedy; this is the underlying fragility.