### PR TITLE
sim: fix resource extraction, on the last file and on Android

### DIFF
--- a/sim/sim-main.cpp
+++ b/sim/sim-main.cpp
@@ -110,10 +110,10 @@ static void copy(const QString &fromName, const QString &toName)
     if (!to.exists())
         to.mkpath(toName);
 
-    for (QDirIterator it(fromName, QDirIterator::Subdirectories);
-         it.hasNext();
-         it.next())
+    QDirIterator it(fromName, QDirIterator::Subdirectories);
+    while (it.hasNext())
     {
+        it.next();
         const auto fi = it.fileInfo();
         if (!fi.isHidden())
         {

--- a/sim/sim-main.cpp
+++ b/sim/sim-main.cpp
@@ -44,6 +44,7 @@
 #include <QApplication>
 #include <QByteArray>
 #include <QDirIterator>
+#include <QFile>
 #include <QFont>
 #include <QFontDatabase>
 #include <QStandardPaths>
@@ -531,10 +532,42 @@ int main(int argc, char *argv[])
 
     QString files =
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+
+    // On Android the mere existence of the application data directory does not
+    // mean the resources were extracted: the Qt bootstrap creates it before we
+    // run, so the existence test never fired and the library was never
+    // installed. Stamp the extracted tree with the version there, and
+    // re-extract whenever that stamp is missing or stale, which also refreshes
+    // the resources when the application is updated in place.
+#ifdef ANDROID
+    QString  stampPath = files + "/.assets-version";
+    QString  wanted    = DB48X_VERSION;
+    QString  found;
+    QFile    stamp(stampPath);
+    if (stamp.open(QIODevice::ReadOnly))
+    {
+        found = QString::fromUtf8(stamp.readAll()).trimmed();
+        stamp.close();
+    }
+    if (getenv("DB48X_INSTALL") || found != wanted)
+        install = true;
+    if (install)
+    {
+        copy(":/", files);
+        if (stamp.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        {
+            stamp.write(wanted.toUtf8());
+            stamp.close();
+        }
+    }
+#else // !ANDROID
+    // On a desktop the data directory is created by us alone, so its absence
+    // still is the right signal, and the version changes at every commit.
     if (getenv("DB48X_INSTALL") || !QDir(files).exists())
         install = true;
     if (install)
         copy(":/", files);
+#endif // ANDROID
     QDir::setCurrent(files);
     QDir::current().mkdir("screens");
 


### PR DESCRIPTION
Three lines. `copy()` in `sim/sim-main.cpp` drives `QDirIterator` from the third clause of a `for` loop:

```c
for (QDirIterator it(fromName, QDirIterator::Subdirectories);
     it.hasNext();
     it.next())
{
    const auto fi = it.fileInfo();
```

`QDirIterator::fileInfo()` describes the entry returned by the **last call to `next()`**. Written this way the body sees the *previous* entry on every turn: the first iteration reads an empty `QFileInfo`, and the final entry of the whole tree is never copied at all.

## What it costs

Exactly one file is missing from every fresh install, with no error and nothing to say which one. Which file it is depends on `rcc`'s ordering rather than on anything an author controls, so it moves as the resource tree changes — which is why it has been invisible.

I met it as a help figure that would not display. The `.qrc` listed the file, the repository contained it, `help/img/` contained it, and the sandbox simply did not. The count is what gave it away: 157 entries in `sim/help/img.qrc`, 156 files extracted.

With the loop written the usual way, 157 entries extract 157 files.

## Scope

The simulator only. On hardware the files are read from the FAT disk directly and never go through this path.

It is worth having independently of what surfaced it: as things stand, any addition to the resource tree silently drops one file somewhere else in that tree.

## Checked

- Cherry-picks cleanly onto `dev` and builds there — `make sim NAME=db48x`, no warnings.
- `tests -Texamples` on my working branch: 1021 tests, unchanged failures.

The same family as #1723, #1726 and #1730, all around resource packaging and extraction, but independent of them: it touches one file none of those touch.

## A second cause, found on Android

The loop above is real, but on Android it was not what emptied the Function Library. `main()` decides whether to extract with `getenv("DB48X_INSTALL") || !QDir(files).exists()`, and on Android that directory already exists by the time `main()` runs, because the Qt bootstrap creates it. The test never fires, `copy(":/", files)` is never called, and nothing is ever extracted — on a first install as much as on an update.

What the phone showed: a fresh install left 1 MB under `files/`, holding `help/db48x.idx` and `help/db48x.md` and nothing else. Those two are written by `sim-window.cpp` itself, not by `copy()`. No `library/`, no figures, no `config/`. The Function Library was down to the entries compiled into `basic_library[]`.

The second commit stamps the extracted tree with `DB48X_VERSION` and re-extracts whenever that stamp is missing or stale. The existence test stays on desktop builds, where we alone create that directory and where the version changes at every commit, so that a rebuild does not overwrite a working library.

Measured on a Galaxy S20 FE, with both commits applied on top of a branch carrying the full library, installing over the broken install without uninstalling: 360 library entries and 158 figures extracted, all 339 file references in `config/library.csv` resolved, and the stamp moved from `0.9.20-5-60b3Z` to `0.9.20-208-1fa5Z`.