### PR TITLE
CI: Upload Android .apk; drop help files from .aab upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,7 +497,17 @@ jobs:
         path: |
           android/*.aab
           android/**/*.aab
-          help/
+
+    - name: Rename Android .apk
+      run: ln -s android/build/outputs/apk/debug/android-debug.apk db48x.apk
+
+    - name: Upload Android .apk artifact
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        path: |
+          db48x.apk
+        archive: false
 
   build-color-android:
     name: Build Android App (db50x)
@@ -568,7 +578,17 @@ jobs:
         path: |
           android/*.aab
           android/**/*.aab
-          help/
+
+    - name: Rename Android .apk
+      run: ln -s android/build/outputs/apk/debug/android-debug.apk db50x.apk
+
+    - name: Upload Android .apk artifact
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        path: |
+          db50x.apk
+        archive: false
 
   build-dm42-firmware:
     name: Build DM42 Firmware


### PR DESCRIPTION
In the process of generating the .aab files an .apk file is generated. It was not included in the uploaded artifacts and thus not available.

As long as the .aab files aren't submitted to the Google Play store side loading an .apk on a device is the best we can do.

So we must keep the .apk file.

I don't think there is any use in uploading help/. The help file should go as assets or resources in the .apk / .aab files

Signed-off-by: Ed@vanGasteren.net